### PR TITLE
Add reusable traceability test harness for issues #2/#3

### DIFF
--- a/docs/test-harness-integration-notes.md
+++ b/docs/test-harness-integration-notes.md
@@ -1,0 +1,28 @@
+# Test Harness Integration Notes (#2/#3)
+
+This harness is intentionally stage-agnostic so issue #2 and issue #3 can share setup code without coupling tests to provider-specific outputs.
+
+## Provided modules
+
+- `tests/support/fixtures.py`
+  - `make_taxonomy_node()`
+  - `make_meta_prompt()`
+  - `make_instantiation()`
+- `tests/support/traceability.py`
+  - `assert_meta_prompt_traceability()`
+  - `assert_instantiation_traceability()`
+
+## Expected integration points
+
+- Issue #2 tests should validate taxonomy linkage by asserting every produced `meta_prompt` carries `taxonomy_node_id`.
+- Issue #3 tests should validate instantiation lineage by asserting each `instantiation` carries:
+  - root `meta_prompt_id`
+  - nested `lineage.meta_prompt_id`
+  - nested `lineage.taxonomy_node_id`
+- If #2/#3 add extra metadata fields, keep them additive; do not remove current traceability keys.
+
+## Design constraints
+
+- No concrete provider model IDs or API response shapes are embedded in fixtures.
+- Fixture IDs are deterministic and human-readable to simplify assertion diffs.
+- Assertions fail with explicit expected/actual values to improve debugging speed.

--- a/tests/support/__init__.py
+++ b/tests/support/__init__.py
@@ -1,0 +1,10 @@
+from .fixtures import make_instantiation, make_meta_prompt, make_taxonomy_node
+from .traceability import assert_instantiation_traceability, assert_meta_prompt_traceability
+
+__all__ = [
+    "make_taxonomy_node",
+    "make_meta_prompt",
+    "make_instantiation",
+    "assert_meta_prompt_traceability",
+    "assert_instantiation_traceability",
+]

--- a/tests/support/fixtures.py
+++ b/tests/support/fixtures.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+
+def make_taxonomy_node(
+    node_slug: str,
+    *,
+    label: str | None = None,
+    parent_node_id: str | None = None,
+) -> dict[str, str]:
+    taxonomy_node_id = f"tax-{node_slug}"
+    node = {
+        "taxonomy_node_id": taxonomy_node_id,
+        "node_slug": node_slug,
+        "label": label or node_slug.replace("-", " ").title(),
+    }
+    if parent_node_id is not None:
+        node["parent_taxonomy_node_id"] = parent_node_id
+    return node
+
+
+def make_meta_prompt(
+    meta_prompt_id: str,
+    *,
+    taxonomy_node_id: str,
+    prompt_text: str | None = None,
+) -> dict[str, str]:
+    return {
+        "meta_prompt_id": meta_prompt_id,
+        "taxonomy_node_id": taxonomy_node_id,
+        "prompt_text": prompt_text or f"Draft scenario for {taxonomy_node_id}",
+    }
+
+
+def make_instantiation(
+    instantiation_id: str,
+    *,
+    meta_prompt_id: str,
+    taxonomy_node_id: str | None = None,
+    payload: str | None = None,
+) -> dict[str, object]:
+    lineage_taxonomy_node_id = taxonomy_node_id or _taxonomy_node_id_from_meta_prompt(meta_prompt_id)
+    return {
+        "instantiation_id": instantiation_id,
+        "meta_prompt_id": meta_prompt_id,
+        "payload": payload or f"Sample output for {meta_prompt_id}",
+        "lineage": {
+            "meta_prompt_id": meta_prompt_id,
+            "taxonomy_node_id": lineage_taxonomy_node_id,
+            "instantiation_id": instantiation_id,
+        },
+    }
+
+
+def _taxonomy_node_id_from_meta_prompt(meta_prompt_id: str) -> str:
+    if "-" not in meta_prompt_id:
+        return "tax-unknown"
+    _, suffix = meta_prompt_id.split("-", 1)
+    return f"tax-{suffix}"

--- a/tests/support/traceability.py
+++ b/tests/support/traceability.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+
+def assert_meta_prompt_traceability(
+    meta_prompt: dict[str, object],
+    *,
+    expected_taxonomy_node_id: str,
+) -> None:
+    actual_taxonomy_node_id = meta_prompt.get("taxonomy_node_id")
+    if actual_taxonomy_node_id != expected_taxonomy_node_id:
+        raise AssertionError(
+            "meta_prompt taxonomy_node_id mismatch: "
+            f"expected={expected_taxonomy_node_id!r} actual={actual_taxonomy_node_id!r}"
+        )
+
+
+def assert_instantiation_traceability(
+    instantiation: dict[str, object],
+    *,
+    expected_meta_prompt_id: str,
+    expected_taxonomy_node_id: str,
+) -> None:
+    actual_meta_prompt_id = instantiation.get("meta_prompt_id")
+    if actual_meta_prompt_id != expected_meta_prompt_id:
+        raise AssertionError(
+            "instantiation meta_prompt_id mismatch: "
+            f"expected={expected_meta_prompt_id!r} actual={actual_meta_prompt_id!r}"
+        )
+
+    lineage = instantiation.get("lineage")
+    if not isinstance(lineage, dict):
+        raise AssertionError("instantiation lineage must be a mapping")
+
+    lineage_meta_prompt_id = lineage.get("meta_prompt_id")
+    if lineage_meta_prompt_id != expected_meta_prompt_id:
+        raise AssertionError(
+            "instantiation lineage meta_prompt_id mismatch: "
+            f"expected={expected_meta_prompt_id!r} actual={lineage_meta_prompt_id!r}"
+        )
+
+    lineage_taxonomy_node_id = lineage.get("taxonomy_node_id")
+    if lineage_taxonomy_node_id != expected_taxonomy_node_id:
+        raise AssertionError(
+            "instantiation lineage taxonomy_node_id mismatch: "
+            f"expected={expected_taxonomy_node_id!r} actual={lineage_taxonomy_node_id!r}"
+        )

--- a/tests/test_harness_traceability.py
+++ b/tests/test_harness_traceability.py
@@ -1,0 +1,50 @@
+import unittest
+
+from support.traceability import (
+    assert_instantiation_traceability,
+    assert_meta_prompt_traceability,
+)
+from support.fixtures import make_instantiation, make_meta_prompt, make_taxonomy_node
+
+
+class HarnessFixturesTest(unittest.TestCase):
+    def test_fixture_builders_create_lineage_without_provider_coupling(self) -> None:
+        root = make_taxonomy_node("root", label="Root Topic")
+        child = make_taxonomy_node("child", parent_node_id=root["taxonomy_node_id"])
+        meta_prompt = make_meta_prompt("mp-1", taxonomy_node_id=child["taxonomy_node_id"])
+        instantiation = make_instantiation(
+            "inst-1",
+            meta_prompt_id=meta_prompt["meta_prompt_id"],
+            taxonomy_node_id=meta_prompt["taxonomy_node_id"],
+        )
+
+        self.assertEqual(root["taxonomy_node_id"], "tax-root")
+        self.assertEqual(child["parent_taxonomy_node_id"], "tax-root")
+        self.assertEqual(meta_prompt["taxonomy_node_id"], "tax-child")
+        self.assertEqual(instantiation["meta_prompt_id"], "mp-1")
+        self.assertEqual(instantiation["lineage"]["taxonomy_node_id"], "tax-child")
+
+
+class HarnessAssertionsTest(unittest.TestCase):
+    def test_traceability_assertions_validate_expected_lineage(self) -> None:
+        node = make_taxonomy_node("finance")
+        meta_prompt = make_meta_prompt("mp-2", taxonomy_node_id=node["taxonomy_node_id"])
+        instantiation = make_instantiation(
+            "inst-2",
+            meta_prompt_id=meta_prompt["meta_prompt_id"],
+            taxonomy_node_id=meta_prompt["taxonomy_node_id"],
+        )
+
+        assert_meta_prompt_traceability(
+            meta_prompt,
+            expected_taxonomy_node_id="tax-finance",
+        )
+        assert_instantiation_traceability(
+            instantiation,
+            expected_meta_prompt_id="mp-2",
+            expected_taxonomy_node_id="tax-finance",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add reusable taxonomy/meta-prompt fixture builders in `tests/support/fixtures.py`
- add traceability assertion helpers in `tests/support/traceability.py`
- add harness demonstration tests and integration notes for downstream issue #2/#3 implementation

## Why
Wave 1 prompt B asks for reusable test harness support that accelerates issue #2 and issue #3 while staying decoupled from model providers.

## Linked issues
- Refs #2
- Refs #3

## Test plan
- `PYTHONPATH=src python3 -m unittest discover -s tests -p \"test_harness_traceability.py\"`

## Notes
- This PR is stacked on top of `feature/issue-6-9-validator-utilities` to keep parallel slices reviewable.

Made with [Cursor](https://cursor.com)