### PR TITLE
Add manifest and artifact validator utilities for reproducibility checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Python bytecode and cache
+__pycache__/
+*.py[cod]
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Build and packaging outputs
+build/
+dist/
+*.egg-info/
+
+# Test and coverage artifacts
+.pytest_cache/
+.coverage
+htmlcov/

--- a/docs/test-harness-integration-notes.md
+++ b/docs/test-harness-integration-notes.md
@@ -1,0 +1,28 @@
+# Test Harness Integration Notes (#2/#3)
+
+This harness is intentionally stage-agnostic so issue #2 and issue #3 can share setup code without coupling tests to provider-specific outputs.
+
+## Provided modules
+
+- `tests/support/fixtures.py`
+  - `make_taxonomy_node()`
+  - `make_meta_prompt()`
+  - `make_instantiation()`
+- `tests/support/traceability.py`
+  - `assert_meta_prompt_traceability()`
+  - `assert_instantiation_traceability()`
+
+## Expected integration points
+
+- Issue #2 tests should validate taxonomy linkage by asserting every produced `meta_prompt` carries `taxonomy_node_id`.
+- Issue #3 tests should validate instantiation lineage by asserting each `instantiation` carries:
+  - root `meta_prompt_id`
+  - nested `lineage.meta_prompt_id`
+  - nested `lineage.taxonomy_node_id`
+- If #2/#3 add extra metadata fields, keep them additive; do not remove current traceability keys.
+
+## Design constraints
+
+- No concrete provider model IDs or API response shapes are embedded in fixtures.
+- Fixture IDs are deterministic and human-readable to simplify assertion diffs.
+- Assertions fail with explicit expected/actual values to improve debugging speed.

--- a/src/simula_research/__init__.py
+++ b/src/simula_research/__init__.py
@@ -1,3 +1,4 @@
 from simula_research.pipeline import run_pipeline
+from simula_research.validators import validate_artifact_tree, validate_manifest_schema
 
-__all__ = ["run_pipeline"]
+__all__ = ["run_pipeline", "validate_manifest_schema", "validate_artifact_tree"]

--- a/src/simula_research/validators.py
+++ b/src/simula_research/validators.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+# Reproducibility-ops required manifest fields.
+REQUIRED_MANIFEST_FIELDS: tuple[str, ...] = (
+    "run_id",
+    "created_at_utc",
+    "owner",
+    "branch",
+    "commit_hash",
+    "artifact_schema_version",
+    "domain_objective",
+    "seed",
+    "model_ids",
+    "pipeline_config",
+    "protocol_version",
+    "baseline_or_ablation_tag",
+)
+
+# Reproducibility-ops stable artifact layout conventions.
+REQUIRED_ARTIFACT_STAGES: tuple[str, ...] = (
+    "00_spec",
+    "10_taxonomy",
+    "20_local_diversification",
+    "30_complexification",
+    "40_dual_critic",
+    "50_curated_dataset",
+    "60_evaluation",
+    "70_diagnostics",
+)
+
+
+def _validation_result(kind: str, issues: list[str], assumptions: list[str]) -> dict[str, Any]:
+    return {
+        "ok": len(issues) == 0,
+        "kind": kind,
+        "issues": issues,
+        "assumptions": assumptions,
+    }
+
+
+def validate_manifest_schema(manifest: dict[str, Any]) -> dict[str, Any]:
+    issues: list[str] = []
+    assumptions = [
+        "Manifest payload is already parsed as JSON object",
+        "Model identifiers are represented as strings in model_ids",
+        "pipeline_config can be any JSON object shape as long as it is present",
+    ]
+
+    for field in REQUIRED_MANIFEST_FIELDS:
+        if field not in manifest:
+            issues.append(f"missing required field: {field}")
+
+    if "run_id" in manifest and (not isinstance(manifest["run_id"], str) or not manifest["run_id"].strip()):
+        issues.append("field run_id must be a non-empty string")
+
+    if "seed" in manifest and not isinstance(manifest["seed"], int):
+        issues.append("field seed must be an integer")
+
+    if "model_ids" in manifest:
+        model_ids = manifest["model_ids"]
+        if not isinstance(model_ids, dict) or not model_ids:
+            issues.append("field model_ids must be a non-empty object")
+        elif any(not isinstance(value, str) or not value.strip() for value in model_ids.values()):
+            issues.append("field model_ids must map to non-empty string identifiers")
+
+    for field in ("protocol_version", "artifact_schema_version", "baseline_or_ablation_tag"):
+        if field in manifest and (not isinstance(manifest[field], str) or not manifest[field].strip()):
+            issues.append(f"field {field} must be a non-empty string")
+
+    if "pipeline_config" in manifest and not isinstance(manifest["pipeline_config"], dict):
+        issues.append("field pipeline_config must be an object")
+
+    return _validation_result(kind="manifest", issues=issues, assumptions=assumptions)
+
+
+def validate_artifact_tree(run_root: str | Path) -> dict[str, Any]:
+    root_path = Path(run_root)
+    issues: list[str] = []
+    assumptions = [
+        "run_root points to artifacts/runs/<run_id>",
+        "Required stages are represented as directories directly under run_root",
+        "Validation checks folder presence only, not internal file completeness",
+    ]
+
+    if not root_path.exists():
+        issues.append(f"run root does not exist: {root_path}")
+        return _validation_result(kind="artifacts", issues=issues, assumptions=assumptions)
+
+    if not root_path.is_dir():
+        issues.append(f"run root is not a directory: {root_path}")
+        return _validation_result(kind="artifacts", issues=issues, assumptions=assumptions)
+
+    for stage_dir in REQUIRED_ARTIFACT_STAGES:
+        stage_path = root_path / stage_dir
+        if not stage_path.exists() or not stage_path.is_dir():
+            issues.append(f"missing required artifact stage directory: {stage_dir}")
+
+    return _validation_result(kind="artifacts", issues=issues, assumptions=assumptions)

--- a/tests/support/__init__.py
+++ b/tests/support/__init__.py
@@ -1,0 +1,10 @@
+from .fixtures import make_instantiation, make_meta_prompt, make_taxonomy_node
+from .traceability import assert_instantiation_traceability, assert_meta_prompt_traceability
+
+__all__ = [
+    "make_taxonomy_node",
+    "make_meta_prompt",
+    "make_instantiation",
+    "assert_meta_prompt_traceability",
+    "assert_instantiation_traceability",
+]

--- a/tests/support/fixtures.py
+++ b/tests/support/fixtures.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+
+def make_taxonomy_node(
+    node_slug: str,
+    *,
+    label: str | None = None,
+    parent_node_id: str | None = None,
+) -> dict[str, str]:
+    taxonomy_node_id = f"tax-{node_slug}"
+    node = {
+        "taxonomy_node_id": taxonomy_node_id,
+        "node_slug": node_slug,
+        "label": label or node_slug.replace("-", " ").title(),
+    }
+    if parent_node_id is not None:
+        node["parent_taxonomy_node_id"] = parent_node_id
+    return node
+
+
+def make_meta_prompt(
+    meta_prompt_id: str,
+    *,
+    taxonomy_node_id: str,
+    prompt_text: str | None = None,
+) -> dict[str, str]:
+    return {
+        "meta_prompt_id": meta_prompt_id,
+        "taxonomy_node_id": taxonomy_node_id,
+        "prompt_text": prompt_text or f"Draft scenario for {taxonomy_node_id}",
+    }
+
+
+def make_instantiation(
+    instantiation_id: str,
+    *,
+    meta_prompt_id: str,
+    taxonomy_node_id: str | None = None,
+    payload: str | None = None,
+) -> dict[str, object]:
+    lineage_taxonomy_node_id = taxonomy_node_id or _taxonomy_node_id_from_meta_prompt(meta_prompt_id)
+    return {
+        "instantiation_id": instantiation_id,
+        "meta_prompt_id": meta_prompt_id,
+        "payload": payload or f"Sample output for {meta_prompt_id}",
+        "lineage": {
+            "meta_prompt_id": meta_prompt_id,
+            "taxonomy_node_id": lineage_taxonomy_node_id,
+            "instantiation_id": instantiation_id,
+        },
+    }
+
+
+def _taxonomy_node_id_from_meta_prompt(meta_prompt_id: str) -> str:
+    if "-" not in meta_prompt_id:
+        return "tax-unknown"
+    _, suffix = meta_prompt_id.split("-", 1)
+    return f"tax-{suffix}"

--- a/tests/support/traceability.py
+++ b/tests/support/traceability.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+
+def assert_meta_prompt_traceability(
+    meta_prompt: dict[str, object],
+    *,
+    expected_taxonomy_node_id: str,
+) -> None:
+    actual_taxonomy_node_id = meta_prompt.get("taxonomy_node_id")
+    if actual_taxonomy_node_id != expected_taxonomy_node_id:
+        raise AssertionError(
+            "meta_prompt taxonomy_node_id mismatch: "
+            f"expected={expected_taxonomy_node_id!r} actual={actual_taxonomy_node_id!r}"
+        )
+
+
+def assert_instantiation_traceability(
+    instantiation: dict[str, object],
+    *,
+    expected_meta_prompt_id: str,
+    expected_taxonomy_node_id: str,
+) -> None:
+    actual_meta_prompt_id = instantiation.get("meta_prompt_id")
+    if actual_meta_prompt_id != expected_meta_prompt_id:
+        raise AssertionError(
+            "instantiation meta_prompt_id mismatch: "
+            f"expected={expected_meta_prompt_id!r} actual={actual_meta_prompt_id!r}"
+        )
+
+    lineage = instantiation.get("lineage")
+    if not isinstance(lineage, dict):
+        raise AssertionError("instantiation lineage must be a mapping")
+
+    lineage_meta_prompt_id = lineage.get("meta_prompt_id")
+    if lineage_meta_prompt_id != expected_meta_prompt_id:
+        raise AssertionError(
+            "instantiation lineage meta_prompt_id mismatch: "
+            f"expected={expected_meta_prompt_id!r} actual={lineage_meta_prompt_id!r}"
+        )
+
+    lineage_taxonomy_node_id = lineage.get("taxonomy_node_id")
+    if lineage_taxonomy_node_id != expected_taxonomy_node_id:
+        raise AssertionError(
+            "instantiation lineage taxonomy_node_id mismatch: "
+            f"expected={expected_taxonomy_node_id!r} actual={lineage_taxonomy_node_id!r}"
+        )

--- a/tests/test_harness_traceability.py
+++ b/tests/test_harness_traceability.py
@@ -1,0 +1,50 @@
+import unittest
+
+from support.traceability import (
+    assert_instantiation_traceability,
+    assert_meta_prompt_traceability,
+)
+from support.fixtures import make_instantiation, make_meta_prompt, make_taxonomy_node
+
+
+class HarnessFixturesTest(unittest.TestCase):
+    def test_fixture_builders_create_lineage_without_provider_coupling(self) -> None:
+        root = make_taxonomy_node("root", label="Root Topic")
+        child = make_taxonomy_node("child", parent_node_id=root["taxonomy_node_id"])
+        meta_prompt = make_meta_prompt("mp-1", taxonomy_node_id=child["taxonomy_node_id"])
+        instantiation = make_instantiation(
+            "inst-1",
+            meta_prompt_id=meta_prompt["meta_prompt_id"],
+            taxonomy_node_id=meta_prompt["taxonomy_node_id"],
+        )
+
+        self.assertEqual(root["taxonomy_node_id"], "tax-root")
+        self.assertEqual(child["parent_taxonomy_node_id"], "tax-root")
+        self.assertEqual(meta_prompt["taxonomy_node_id"], "tax-child")
+        self.assertEqual(instantiation["meta_prompt_id"], "mp-1")
+        self.assertEqual(instantiation["lineage"]["taxonomy_node_id"], "tax-child")
+
+
+class HarnessAssertionsTest(unittest.TestCase):
+    def test_traceability_assertions_validate_expected_lineage(self) -> None:
+        node = make_taxonomy_node("finance")
+        meta_prompt = make_meta_prompt("mp-2", taxonomy_node_id=node["taxonomy_node_id"])
+        instantiation = make_instantiation(
+            "inst-2",
+            meta_prompt_id=meta_prompt["meta_prompt_id"],
+            taxonomy_node_id=meta_prompt["taxonomy_node_id"],
+        )
+
+        assert_meta_prompt_traceability(
+            meta_prompt,
+            expected_taxonomy_node_id="tax-finance",
+        )
+        assert_instantiation_traceability(
+            instantiation,
+            expected_meta_prompt_id="mp-2",
+            expected_taxonomy_node_id="tax-finance",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from simula_research.validators import (
+    REQUIRED_ARTIFACT_STAGES,
+    validate_artifact_tree,
+    validate_manifest_schema,
+)
+
+
+class ValidatorTests(unittest.TestCase):
+    def _valid_manifest(self) -> dict[str, object]:
+        return {
+            "run_id": "run-20260430T190000Z-abcd1234",
+            "created_at_utc": "2026-04-30T19:00:00Z",
+            "owner": "agent",
+            "branch": "main",
+            "commit_hash": "abc123def456",
+            "artifact_schema_version": "v1",
+            "domain_objective": "synthetic data generation",
+            "seed": 7,
+            "model_ids": {
+                "generator": "gpt-4.1-mini",
+                "critic_a": "gpt-4.1",
+                "critic_b": "gpt-4.1",
+            },
+            "pipeline_config": {"max_nodes": 10},
+            "protocol_version": "0.1.0",
+            "baseline_or_ablation_tag": "B0",
+        }
+
+    def test_manifest_validation_success(self) -> None:
+        result = validate_manifest_schema(self._valid_manifest())
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["kind"], "manifest")
+        self.assertEqual(result["issues"], [])
+
+    def test_manifest_validation_reports_missing_field(self) -> None:
+        manifest = self._valid_manifest()
+        manifest.pop("owner")
+        result = validate_manifest_schema(manifest)
+        self.assertFalse(result["ok"])
+        self.assertIn("missing required field: owner", result["issues"])
+
+    def test_artifact_tree_validation_success(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            run_root = Path(tmp_dir) / "run-1"
+            run_root.mkdir(parents=True, exist_ok=True)
+            for stage_name in REQUIRED_ARTIFACT_STAGES:
+                (run_root / stage_name).mkdir()
+
+            result = validate_artifact_tree(run_root)
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["kind"], "artifacts")
+        self.assertEqual(result["issues"], [])
+
+    def test_artifact_tree_validation_reports_missing_stages(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            run_root = Path(tmp_dir) / "run-2"
+            run_root.mkdir(parents=True, exist_ok=True)
+            (run_root / REQUIRED_ARTIFACT_STAGES[0]).mkdir()
+
+            result = validate_artifact_tree(run_root)
+
+        self.assertFalse(result["ok"])
+        self.assertGreater(len(result["issues"]), 0)
+        self.assertTrue(
+            any("missing required artifact stage directory" in issue for issue in result["issues"])
+        )
+
+    def test_end_to_end_cli_like_usage(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            run_root = Path(tmp_dir) / "run-3"
+            run_root.mkdir(parents=True, exist_ok=True)
+            for stage_name in REQUIRED_ARTIFACT_STAGES:
+                (run_root / stage_name).mkdir()
+            manifest_path = run_root / "manifest.json"
+            manifest_path.write_text(json.dumps(self._valid_manifest()), encoding="utf-8")
+
+            manifest_result = validate_manifest_schema(json.loads(manifest_path.read_text("utf-8")))
+            artifact_result = validate_artifact_tree(run_root)
+
+        self.assertTrue(manifest_result["ok"])
+        self.assertTrue(artifact_result["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `validate_manifest_schema` with required reproducibility metadata checks
- add `validate_artifact_tree` for required stage-directory validation
- add validator tests and export public validator APIs

## Why
Wave 1 prompt C requires machine-readable validation utilities that support issue #6 metrics plumbing and issue #9 reproducibility hardening.

## Linked issues
- Refs #6
- Refs #9

## Test plan
- `PYTHONPATH=src python3 -m unittest discover -s tests -p \"test_validators.py\"`

Made with [Cursor](https://cursor.com)