### PR TITLE
Implement Issue #2 global diversification taxonomy stage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Python bytecode and cache
+__pycache__/
+*.py[cod]
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Build and packaging outputs
+build/
+dist/
+*.egg-info/
+
+# Test and coverage artifacts
+.pytest_cache/
+.coverage
+htmlcov/

--- a/src/simula_research/pipeline.py
+++ b/src/simula_research/pipeline.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
 from uuid import uuid4
 
 from simula_research.manifest import validate_manifest
+from simula_research.taxonomy import TaxonomyConfig, build_taxonomy
 
 PROTOCOL_VERSION = "0.1.0"
 ARTIFACT_SCHEMA_VERSION = "0.1.0"
@@ -18,7 +22,41 @@ STAGE_NAMES = [
 ]
 
 
-def run_pipeline(seed: int, model_ids: dict[str, str]) -> dict[str, object]:
+def _persist_taxonomy_artifacts(run_root: Path, taxonomy: dict[str, Any]) -> dict[str, str]:
+    taxonomy_dir = run_root / "10_taxonomy"
+    taxonomy_dir.mkdir(parents=True, exist_ok=True)
+
+    graph_path = taxonomy_dir / "taxonomy_graph.json"
+    nodes_path = taxonomy_dir / "taxonomy_nodes.json"
+
+    graph_path.write_text(
+        json.dumps(
+            {
+                "domain_namespace": taxonomy["domain_namespace"],
+                "root_taxonomy_node_id": taxonomy["root_taxonomy_node_id"],
+                "edges": taxonomy["edges"],
+                "generation_policy": taxonomy["generation_policy"],
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    nodes_path.write_text(json.dumps(taxonomy["nodes"], indent=2, sort_keys=True), encoding="utf-8")
+
+    return {
+        "taxonomy_graph": str(graph_path),
+        "taxonomy_nodes": str(nodes_path),
+    }
+
+
+def run_pipeline(
+    seed: int,
+    model_ids: dict[str, str],
+    domain_objective: str = "pilot-domain",
+    artifact_root: str | Path = "artifacts/runs",
+    taxonomy_config: dict[str, int] | None = None,
+) -> dict[str, object]:
     run_id = f"run-{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}-{uuid4().hex[:8]}"
 
     manifest = {
@@ -30,8 +68,42 @@ def run_pipeline(seed: int, model_ids: dict[str, str]) -> dict[str, object]:
     }
     validate_manifest(manifest)
 
-    stage_outputs = {
+    stage_outputs: dict[str, Any] = {
         stage_name: {"status": "placeholder", "run_id": run_id} for stage_name in STAGE_NAMES
     }
 
-    return {"manifest": manifest, "stage_outputs": stage_outputs}
+    cfg = taxonomy_config or {}
+    taxonomy = build_taxonomy(
+        domain_objective=domain_objective,
+        config=TaxonomyConfig(
+            max_depth=int(cfg.get("max_depth", 2)),
+            branching_factor=int(cfg.get("branching_factor", 2)),
+        ),
+    )
+
+    run_root = Path(artifact_root) / run_id
+    artifacts = _persist_taxonomy_artifacts(run_root=run_root, taxonomy=taxonomy)
+
+    stage_outputs["stage_1_global_diversification"] = {
+        "status": "completed",
+        "run_id": run_id,
+        "taxonomy_root_node_id": taxonomy["root_taxonomy_node_id"],
+        "taxonomy_node_count": len(taxonomy["nodes"]),
+        "taxonomy_edge_count": len(taxonomy["edges"]),
+        "taxonomy_artifacts": artifacts,
+        "handoff_contract_issue_3": {
+            "required_fields_per_taxonomy_node": [
+                "taxonomy_node_id",
+                "parent_taxonomy_node_id",
+                "label",
+                "depth",
+            ],
+            "traceability_fields_for_local_diversification": [
+                "taxonomy_node_id",
+                "meta_prompt_id",
+                "instantiation_id",
+            ],
+        },
+    }
+
+    return {"manifest": manifest, "stage_outputs": stage_outputs, "taxonomy": taxonomy}

--- a/src/simula_research/taxonomy.py
+++ b/src/simula_research/taxonomy.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha1
+from typing import Any
+
+
+@dataclass(frozen=True)
+class TaxonomyConfig:
+    max_depth: int = 2
+    branching_factor: int = 2
+
+
+def _normalize_label(label: str) -> str:
+    return " ".join(label.strip().lower().split())
+
+
+def _taxonomy_node_id(namespace: str, parent_node_id: str | None, label: str) -> str:
+    canonical_parent = parent_node_id or "root"
+    canonical_label = _normalize_label(label)
+    digest = sha1(f"{namespace}|{canonical_parent}|{canonical_label}".encode("utf-8")).hexdigest()[:12]
+    return f"tax-{digest}"
+
+
+def _seed_terms(domain_objective: str) -> list[str]:
+    cleaned = "".join(ch if ch.isalnum() or ch.isspace() else " " for ch in domain_objective)
+    tokens = [_normalize_label(token) for token in cleaned.split() if token.strip()]
+    unique_tokens: list[str] = []
+    for token in tokens:
+        if token not in unique_tokens:
+            unique_tokens.append(token)
+    if not unique_tokens:
+        return ["core"]
+    return unique_tokens[:3]
+
+
+def _candidate_labels(parent_label: str, depth: int, seed_terms: list[str]) -> list[str]:
+    # Intentionally emits near-duplicates so merge/filter checks are exercised.
+    term = seed_terms[depth % len(seed_terms)]
+    return [
+        f"{parent_label} {term} fundamentals",
+        f"{parent_label} {term} advanced",
+        f"  {parent_label} {term} fundamentals  ",
+    ]
+
+
+def _merge_and_filter(parent_label: str, candidate_labels: list[str], branching_factor: int) -> list[str]:
+    merged: list[str] = []
+    parent_norm = _normalize_label(parent_label)
+    for label in candidate_labels:
+        normalized = _normalize_label(label)
+        if not normalized or normalized == parent_norm:
+            continue
+        if normalized not in merged:
+            merged.append(normalized)
+        if len(merged) >= branching_factor:
+            break
+    return merged
+
+
+def build_taxonomy(domain_objective: str, config: TaxonomyConfig | None = None) -> dict[str, Any]:
+    config = config or TaxonomyConfig()
+    namespace = _normalize_label(domain_objective) or "domain"
+    root_label = f"{namespace} root"
+    root_id = _taxonomy_node_id(namespace, parent_node_id=None, label=root_label)
+
+    nodes: list[dict[str, Any]] = [
+        {
+            "taxonomy_node_id": root_id,
+            "parent_taxonomy_node_id": None,
+            "label": root_label,
+            "depth": 0,
+            "branch_source": "seed",
+            "confidence": 1.0,
+            "notes": "root taxonomy node",
+        }
+    ]
+    edges: list[dict[str, str]] = []
+
+    seed_terms = _seed_terms(domain_objective)
+    queue: list[dict[str, Any]] = [nodes[0]]
+
+    while queue:
+        parent = queue.pop(0)
+        parent_depth = int(parent["depth"])
+        if parent_depth >= config.max_depth:
+            continue
+
+        raw_candidates = _candidate_labels(str(parent["label"]), parent_depth, seed_terms)
+        candidate_labels = _merge_and_filter(
+            parent_label=str(parent["label"]),
+            candidate_labels=raw_candidates,
+            branching_factor=config.branching_factor,
+        )
+
+        for label in candidate_labels:
+            child_id = _taxonomy_node_id(namespace, str(parent["taxonomy_node_id"]), label)
+            child = {
+                "taxonomy_node_id": child_id,
+                "parent_taxonomy_node_id": parent["taxonomy_node_id"],
+                "label": label,
+                "depth": parent_depth + 1,
+                "branch_source": "recursive-expansion",
+                "confidence": 0.8,
+                "notes": f"generated from parent {parent['taxonomy_node_id']}",
+            }
+            nodes.append(child)
+            edges.append(
+                {"parent_taxonomy_node_id": str(parent["taxonomy_node_id"]), "taxonomy_node_id": child_id}
+            )
+            queue.append(child)
+
+    return {
+        "domain_namespace": namespace,
+        "root_taxonomy_node_id": root_id,
+        "nodes": nodes,
+        "edges": edges,
+        "generation_policy": {
+            "max_depth": config.max_depth,
+            "branching_factor": config.branching_factor,
+            "merge_filter_strategy": "normalize+deduplicate+parent-filter",
+        },
+    }

--- a/tests/test_issue1_tracer_bullet.py
+++ b/tests/test_issue1_tracer_bullet.py
@@ -36,8 +36,12 @@ class Issue1TracerBulletTest(unittest.TestCase):
         )
 
         for stage_name, stage_output in stage_outputs.items():
-            self.assertEqual(stage_output["status"], "placeholder")
             self.assertEqual(stage_output["run_id"], manifest["run_id"], msg=stage_name)
+            if stage_name == "stage_1_global_diversification":
+                self.assertEqual(stage_output["status"], "completed")
+                self.assertIn("taxonomy_root_node_id", stage_output)
+            else:
+                self.assertEqual(stage_output["status"], "placeholder")
 
 
 if __name__ == "__main__":

--- a/tests/test_issue2_taxonomy_stage.py
+++ b/tests/test_issue2_taxonomy_stage.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from simula_research.pipeline import run_pipeline
+
+
+class Issue2TaxonomyStageTest(unittest.TestCase):
+    def test_taxonomy_graph_is_acyclic_and_has_no_orphans(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result = run_pipeline(
+                seed=11,
+                model_ids={"generator": "gpt-4.1-mini", "critic_a": "gpt-4.1", "critic_b": "gpt-4.1"},
+                domain_objective="financial compliance automation",
+                artifact_root=tmp_dir,
+                taxonomy_config={"max_depth": 2, "branching_factor": 2},
+            )
+
+        taxonomy = result["taxonomy"]
+        nodes = taxonomy["nodes"]
+        edges = taxonomy["edges"]
+
+        node_ids = {node["taxonomy_node_id"] for node in nodes}
+        self.assertEqual(len(node_ids), len(nodes), "taxonomy_node_id values must be unique")
+        self.assertEqual(len(edges), len(nodes) - 1, "tree expansion should produce node_count-1 edges")
+
+        root_id = taxonomy["root_taxonomy_node_id"]
+        self.assertIn(root_id, node_ids)
+
+        parent_index = {node["taxonomy_node_id"]: node["parent_taxonomy_node_id"] for node in nodes}
+        self.assertIsNone(parent_index[root_id])
+
+        for node in nodes:
+            node_id = node["taxonomy_node_id"]
+            parent_id = node["parent_taxonomy_node_id"]
+            if node_id == root_id:
+                continue
+            self.assertIsNotNone(parent_id, msg=f"non-root node {node_id} missing parent")
+            self.assertIn(parent_id, node_ids, msg=f"orphan node {node_id}")
+
+            visited: set[str] = set()
+            cursor = node_id
+            while cursor is not None:
+                self.assertNotIn(cursor, visited, msg=f"cycle detected at {cursor}")
+                visited.add(cursor)
+                cursor = parent_index[cursor]
+            self.assertIn(root_id, visited, msg=f"node {node_id} does not connect to root")
+
+    def test_taxonomy_node_ids_are_stable_for_same_inputs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            first = run_pipeline(
+                seed=1,
+                model_ids={"generator": "gpt-4.1-mini", "critic_a": "gpt-4.1", "critic_b": "gpt-4.1"},
+                domain_objective="medical triage support",
+                artifact_root=tmp_dir,
+                taxonomy_config={"max_depth": 2, "branching_factor": 2},
+            )
+            second = run_pipeline(
+                seed=999,
+                model_ids={"generator": "gpt-4.1-mini", "critic_a": "gpt-4.1", "critic_b": "gpt-4.1"},
+                domain_objective="medical triage support",
+                artifact_root=tmp_dir,
+                taxonomy_config={"max_depth": 2, "branching_factor": 2},
+            )
+
+        first_ids = [node["taxonomy_node_id"] for node in first["taxonomy"]["nodes"]]
+        second_ids = [node["taxonomy_node_id"] for node in second["taxonomy"]["nodes"]]
+        self.assertEqual(first_ids, second_ids)
+
+    def test_taxonomy_artifacts_and_handoff_contract_are_persisted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result = run_pipeline(
+                seed=5,
+                model_ids={"generator": "gpt-4.1-mini", "critic_a": "gpt-4.1", "critic_b": "gpt-4.1"},
+                domain_objective="customer support routing",
+                artifact_root=tmp_dir,
+                taxonomy_config={"max_depth": 1, "branching_factor": 2},
+            )
+
+            stage_output = result["stage_outputs"]["stage_1_global_diversification"]
+            self.assertEqual(stage_output["status"], "completed")
+
+            graph_path = Path(stage_output["taxonomy_artifacts"]["taxonomy_graph"])
+            nodes_path = Path(stage_output["taxonomy_artifacts"]["taxonomy_nodes"])
+            self.assertTrue(graph_path.exists())
+            self.assertTrue(nodes_path.exists())
+
+            graph_payload = json.loads(graph_path.read_text(encoding="utf-8"))
+            nodes_payload = json.loads(nodes_path.read_text(encoding="utf-8"))
+            self.assertEqual(graph_payload["root_taxonomy_node_id"], result["taxonomy"]["root_taxonomy_node_id"])
+            self.assertEqual(len(nodes_payload), stage_output["taxonomy_node_count"])
+
+            handoff = stage_output["handoff_contract_issue_3"]
+            self.assertIn("required_fields_per_taxonomy_node", handoff)
+            self.assertIn("traceability_fields_for_local_diversification", handoff)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Implement Stage 1 global diversification taxonomy generation with recursive expansion plus merge/filter checks.
- Add deterministic cross-run `taxonomy_node_id` generation and enforce tree invariants via tests (acyclic + no orphan nodes).
- Persist taxonomy artifacts under `10_taxonomy/` and expose a clear handoff contract for Issue #3.

## Test plan
- [x] `PYTHONPATH=src python3 -m unittest discover -s tests -v`
- [x] Verified Stage 1 output marks completion and includes taxonomy artifact paths.

Closes #2

Made with [Cursor](https://cursor.com)