### PR TITLE
Implement Issue #3 local diversification with anti-collapse checks

### DIFF
--- a/src/simula_research/local_diversification.py
+++ b/src/simula_research/local_diversification.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any
+
+
+def _stable_id(*parts: str) -> str:
+    joined = "::".join(parts)
+    return hashlib.sha1(joined.encode("utf-8")).hexdigest()[:12]
+
+
+def _token_set(text: str) -> set[str]:
+    return set(re.findall(r"[a-z0-9]+", text.lower()))
+
+
+def _token_overlap_ratio(left: str, right: str) -> float:
+    left_tokens = _token_set(left)
+    right_tokens = _token_set(right)
+    if not left_tokens or not right_tokens:
+        return 0.0
+    intersection = left_tokens.intersection(right_tokens)
+    denominator = min(len(left_tokens), len(right_tokens))
+    if denominator == 0:
+        return 0.0
+    return len(intersection) / denominator
+
+
+def build_local_diversification(
+    taxonomy: dict[str, Any],
+    per_node_instantiation_count: int = 3,
+    overlap_rejection_threshold: float = 0.8,
+) -> dict[str, Any]:
+    accepted: list[dict[str, Any]] = []
+    rejections: list[dict[str, Any]] = []
+
+    for node in taxonomy["nodes"]:
+        taxonomy_node_id = node["taxonomy_node_id"]
+        label = node["label"]
+        domain = taxonomy["domain_namespace"]
+        meta_prompt_id = f"mp-{_stable_id(taxonomy_node_id, label)}"
+        meta_prompt_text = f"Generate samples for {domain} with focus on {label}"
+
+        kept_for_node: list[dict[str, Any]] = []
+        for idx in range(per_node_instantiation_count):
+            instantiation_id = f"inst-{_stable_id(taxonomy_node_id, str(idx))}"
+            candidate_text = (
+                f"{domain}::{label} example {idx}. "
+                f"Reasoning path for {label} under {taxonomy_node_id}."
+            )
+
+            is_duplicate = any(
+                _token_overlap_ratio(candidate_text, prior["text"]) >= overlap_rejection_threshold
+                for prior in kept_for_node
+            )
+            candidate = {
+                "instantiation_id": instantiation_id,
+                "taxonomy_node_id": taxonomy_node_id,
+                "meta_prompt_id": meta_prompt_id,
+                "lineage": {
+                    "taxonomy_node_id": taxonomy_node_id,
+                    "meta_prompt_id": meta_prompt_id,
+                    "instantiation_id": instantiation_id,
+                },
+                "text": candidate_text,
+            }
+
+            if is_duplicate:
+                rejections.append(
+                    {
+                        "reason": "low_diversity",
+                        "taxonomy_node_id": taxonomy_node_id,
+                        "meta_prompt_id": meta_prompt_id,
+                        "candidate_instantiation_id": instantiation_id,
+                    }
+                )
+                continue
+
+            accepted.append(candidate)
+            kept_for_node.append(candidate)
+
+    return {
+        "instantiations": accepted,
+        "rejections": rejections,
+        "anti_collapse_checks": {
+            "executed": True,
+            "check_name": "token_overlap_rejection",
+            "threshold": overlap_rejection_threshold,
+        },
+    }

--- a/src/simula_research/pipeline.py
+++ b/src/simula_research/pipeline.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+from simula_research.local_diversification import build_local_diversification
 from simula_research.manifest import validate_manifest
 from simula_research.taxonomy import TaxonomyConfig, build_taxonomy
 
@@ -50,6 +51,30 @@ def _persist_taxonomy_artifacts(run_root: Path, taxonomy: dict[str, Any]) -> dic
     }
 
 
+def _persist_local_diversification_artifacts(
+    run_root: Path, local_diversification: dict[str, Any]
+) -> dict[str, str]:
+    local_dir = run_root / "20_local_diversification"
+    local_dir.mkdir(parents=True, exist_ok=True)
+
+    instantiations_path = local_dir / "instantiations.json"
+    rejections_path = local_dir / "rejections.json"
+
+    instantiations_path.write_text(
+        json.dumps(local_diversification["instantiations"], indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    rejections_path.write_text(
+        json.dumps(local_diversification["rejections"], indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    return {
+        "instantiations": str(instantiations_path),
+        "rejections": str(rejections_path),
+    }
+
+
 def run_pipeline(
     seed: int,
     model_ids: dict[str, str],
@@ -83,6 +108,10 @@ def run_pipeline(
 
     run_root = Path(artifact_root) / run_id
     artifacts = _persist_taxonomy_artifacts(run_root=run_root, taxonomy=taxonomy)
+    local_diversification = build_local_diversification(taxonomy=taxonomy)
+    local_artifacts = _persist_local_diversification_artifacts(
+        run_root=run_root, local_diversification=local_diversification
+    )
 
     stage_outputs["stage_1_global_diversification"] = {
         "status": "completed",
@@ -104,6 +133,14 @@ def run_pipeline(
                 "instantiation_id",
             ],
         },
+    }
+    stage_outputs["stage_2_local_diversification"] = {
+        "status": "completed",
+        "run_id": run_id,
+        "instantiation_count": len(local_diversification["instantiations"]),
+        "rejection_count": len(local_diversification["rejections"]),
+        "anti_collapse_checks": local_diversification["anti_collapse_checks"],
+        "local_diversification_artifacts": local_artifacts,
     }
 
     return {"manifest": manifest, "stage_outputs": stage_outputs, "taxonomy": taxonomy}

--- a/tests/test_issue1_tracer_bullet.py
+++ b/tests/test_issue1_tracer_bullet.py
@@ -40,6 +40,9 @@ class Issue1TracerBulletTest(unittest.TestCase):
             if stage_name == "stage_1_global_diversification":
                 self.assertEqual(stage_output["status"], "completed")
                 self.assertIn("taxonomy_root_node_id", stage_output)
+            elif stage_name == "stage_2_local_diversification":
+                self.assertEqual(stage_output["status"], "completed")
+                self.assertTrue(stage_output["anti_collapse_checks"]["executed"])
             else:
                 self.assertEqual(stage_output["status"], "placeholder")
 

--- a/tests/test_issue3_local_diversification.py
+++ b/tests/test_issue3_local_diversification.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from simula_research.local_diversification import build_local_diversification
+from simula_research.pipeline import run_pipeline
+
+
+class Issue3LocalDiversificationTest(unittest.TestCase):
+    def test_local_diversification_produces_traceable_instantiations(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result = run_pipeline(
+                seed=21,
+                model_ids={"generator": "gpt-4.1-mini", "critic_a": "gpt-4.1", "critic_b": "gpt-4.1"},
+                domain_objective="fraud detection workflow",
+                artifact_root=tmp_dir,
+                taxonomy_config={"max_depth": 1, "branching_factor": 2},
+            )
+
+            stage_output = result["stage_outputs"]["stage_2_local_diversification"]
+            self.assertEqual(stage_output["status"], "completed")
+            self.assertTrue(stage_output["anti_collapse_checks"]["executed"])
+
+            instantiations_path = Path(stage_output["local_diversification_artifacts"]["instantiations"])
+            payload = json.loads(instantiations_path.read_text(encoding="utf-8"))
+            self.assertGreater(len(payload), 0)
+
+            for instantiation in payload:
+                self.assertEqual(
+                    instantiation["lineage"]["taxonomy_node_id"], instantiation["taxonomy_node_id"]
+                )
+                self.assertEqual(instantiation["lineage"]["meta_prompt_id"], instantiation["meta_prompt_id"])
+                self.assertIn("instantiation_id", instantiation)
+
+    def test_low_diversity_candidates_are_rejected_and_logged(self) -> None:
+        taxonomy = {
+            "domain_namespace": "customer-support",
+            "root_taxonomy_node_id": "tax-root",
+            "nodes": [
+                {
+                    "taxonomy_node_id": "tax-root",
+                    "parent_taxonomy_node_id": None,
+                    "label": "root support",
+                    "depth": 0,
+                }
+            ],
+            "edges": [],
+            "generation_policy": {"max_depth": 0, "branching_factor": 1},
+        }
+        result = build_local_diversification(
+            taxonomy=taxonomy,
+            per_node_instantiation_count=3,
+            overlap_rejection_threshold=0.75,
+        )
+        self.assertGreater(len(result["rejections"]), 0)
+        rejection = result["rejections"][0]
+        self.assertEqual(rejection["reason"], "low_diversity")
+        self.assertEqual(rejection["taxonomy_node_id"], "tax-root")
+        self.assertIn("meta_prompt_id", rejection)
+        self.assertIn("candidate_instantiation_id", rejection)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add stage-2 local diversification generation with traceability lineage fields
- add anti-collapse rejection logging and persist stage-2 artifacts under `20_local_diversification`
- add Issue #3 tests and update tracer-bullet expectations for stage-2 completion

## Test plan
- [x] `PYTHONPATH=src python3 -m unittest discover -s tests -p 'test_issue3_local_diversification.py' -v`
- [x] `PYTHONPATH=src python3 -m unittest discover -s tests -p 'test_issue1_tracer_bullet.py' -v`
- [x] `PYTHONPATH=src python3 -m unittest discover -s tests -p 'test_issue2_taxonomy_stage.py' -v`
- [x] `PYTHONPATH=src python3 -m unittest discover -s tests -v`

## Handoff
- merge this PR before Wave 2 Prompt B final merge
- downstream branches should rebase onto latest `main` after this lands

Made with [Cursor](https://cursor.com)