### PR TITLE
Add Wave 2 Prompt B baseline/ablation config scaffolding

### DIFF
--- a/docs/parallel-agent-prompts.md
+++ b/docs/parallel-agent-prompts.md
@@ -12,6 +12,8 @@ Use this table as the source of truth for what is actually integrated in `main`.
 | Wave 1 | Prompt A: taxonomy stage | Issue #2, PR #15 | Complete | Taxonomy stage + tests are in `main`. |
 | Wave 1 | Prompt B: harness support | PR #13 (+ commit `27e7e0c` integration) | Complete | Harness fixtures/assertions and integration notes are now in `main`. |
 | Wave 1 | Prompt C: validator utilities | PR #14 (+ commit `86f9ce8` integration) | Complete | Validator APIs and tests are now in `main`. |
+| Wave 2 | Prompt A: local diversification | Issue #3, PR #16 | In review | Merge first in Wave 2 sequence. |
+| Wave 2 | Prompt B: config scaffolding | Issue #7, PR #17 | In review | Rebase on latest `main` after PR #16 merges. |
 
 ## How to use this file
 

--- a/src/simula_research/run_config_presets.py
+++ b/src/simula_research/run_config_presets.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+PRESET_IDS: tuple[str, ...] = ("B0", "A1", "A4")
+COMPARABILITY_FIELDS: tuple[str, ...] = (
+    "domain_objective",
+    "seed",
+    "model_ids",
+    "protocol_version",
+    "artifact_schema_version",
+    "evaluation_protocol_version",
+)
+REQUIRED_PRESET_FIELDS: tuple[str, ...] = (
+    "baseline_or_ablation_tag",
+    "run_label",
+    "hypothesis_focus",
+    "protocol_version",
+    "artifact_schema_version",
+    "evaluation_protocol_version",
+)
+
+_COMMON_COMPARABILITY = {
+    "domain_objective": "pilot-domain",
+    "seed": 7,
+    "model_ids": {
+        "generator": "gpt-4.1-mini",
+        "critic_a": "gpt-4.1",
+        "critic_b": "gpt-4.1",
+    },
+    "protocol_version": "0.1.0",
+    "artifact_schema_version": "v1",
+    "evaluation_protocol_version": "milestone-1",
+}
+
+_PRESETS: dict[str, dict[str, Any]] = {
+    "B0": {
+        **_COMMON_COMPARABILITY,
+        "baseline_or_ablation_tag": "B0",
+        "run_label": "baseline-full-pipeline",
+        "hypothesis_focus": ["H1", "H2", "H3", "H4"],
+        "pipeline_config": {
+            "global_diversification_enabled": True,
+            "local_diversification_enabled": True,
+            "complexification_enabled": True,
+            "dual_critic_enabled": True,
+        },
+    },
+    "A1": {
+        **_COMMON_COMPARABILITY,
+        "baseline_or_ablation_tag": "A1",
+        "run_label": "ablation-no-global-diversification",
+        "hypothesis_focus": ["H1"],
+        "pipeline_config": {
+            "global_diversification_enabled": False,
+            "local_diversification_enabled": True,
+            "complexification_enabled": True,
+            "dual_critic_enabled": True,
+        },
+    },
+    "A4": {
+        **_COMMON_COMPARABILITY,
+        "baseline_or_ablation_tag": "A4",
+        "run_label": "ablation-single-critic",
+        "hypothesis_focus": ["H4"],
+        "pipeline_config": {
+            "global_diversification_enabled": True,
+            "local_diversification_enabled": True,
+            "complexification_enabled": True,
+            "dual_critic_enabled": False,
+            "single_critic_mode": "critic_a",
+        },
+    },
+}
+
+
+def get_config_preset(preset_id: str) -> dict[str, Any]:
+    if preset_id not in _PRESETS:
+        raise ValueError(f"Unsupported preset_id: {preset_id}")
+    return deepcopy(_PRESETS[preset_id])
+
+
+def validate_all_presets() -> dict[str, Any]:
+    issues: list[str] = []
+    missing_fields: dict[str, list[str]] = {}
+    non_comparable_fields: list[str] = []
+
+    for preset_id in PRESET_IDS:
+        preset = _PRESETS[preset_id]
+        missing = [field for field in REQUIRED_PRESET_FIELDS if field not in preset]
+        if missing:
+            missing_fields[preset_id] = missing
+            issues.append(f"{preset_id} missing required fields: {', '.join(missing)}")
+
+    baseline = _PRESETS["B0"]
+    for field in COMPARABILITY_FIELDS:
+        for preset_id in PRESET_IDS:
+            if _PRESETS[preset_id].get(field) != baseline.get(field):
+                non_comparable_fields.append(field)
+                issues.append(f"Comparability field {field} differs for preset {preset_id}")
+                break
+
+    return {
+        "ok": len(issues) == 0,
+        "issues": issues,
+        "missing_fields": missing_fields,
+        "non_comparable_fields": non_comparable_fields,
+    }
+
+
+def build_run_request(preset_id: str) -> dict[str, Any]:
+    preset = get_config_preset(preset_id)
+    return {
+        "domain_objective": preset["domain_objective"],
+        "seed": preset["seed"],
+        "model_ids": preset["model_ids"],
+        "pipeline_config": preset["pipeline_config"],
+        "manifest_metadata": {
+            field: preset[field]
+            for field in REQUIRED_PRESET_FIELDS
+        },
+    }

--- a/tests/test_wave2_config_scaffolding.py
+++ b/tests/test_wave2_config_scaffolding.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import unittest
+
+from simula_research.run_config_presets import (
+    PRESET_IDS,
+    REQUIRED_PRESET_FIELDS,
+    build_run_request,
+    get_config_preset,
+    validate_all_presets,
+)
+
+
+class Wave2ConfigScaffoldingTest(unittest.TestCase):
+    def test_required_presets_exist_with_labels(self) -> None:
+        self.assertEqual(PRESET_IDS, ("B0", "A1", "A4"))
+        for preset_id in PRESET_IDS:
+            preset = get_config_preset(preset_id)
+            self.assertEqual(preset["baseline_or_ablation_tag"], preset_id)
+            self.assertIsInstance(preset["run_label"], str)
+            self.assertTrue(preset["run_label"])
+
+    def test_preset_validation_enforces_frozen_comparability_fields(self) -> None:
+        result = validate_all_presets()
+        self.assertEqual(result["issues"], [])
+        self.assertEqual(result["missing_fields"], {})
+        self.assertEqual(result["non_comparable_fields"], [])
+
+    def test_runner_request_contains_required_manifest_metadata(self) -> None:
+        request = build_run_request("A4")
+        self.assertEqual(request["seed"], 7)
+        self.assertEqual(
+            request["model_ids"],
+            {"generator": "gpt-4.1-mini", "critic_a": "gpt-4.1", "critic_b": "gpt-4.1"},
+        )
+        self.assertEqual(request["manifest_metadata"]["baseline_or_ablation_tag"], "A4")
+        self.assertEqual(request["manifest_metadata"]["protocol_version"], "0.1.0")
+        self.assertEqual(request["manifest_metadata"]["artifact_schema_version"], "v1")
+        self.assertEqual(request["manifest_metadata"]["evaluation_protocol_version"], "milestone-1")
+        self.assertEqual(
+            set(request["manifest_metadata"].keys()),
+            set(REQUIRED_PRESET_FIELDS),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add explicit run config presets for `B0`, `A1`, and `A4`
- enforce comparability field invariants across presets via validation API
- add run-request builder and focused tests for scaffold contract

## Test plan
- [x] `PYTHONPATH=src python3 -m unittest discover -s tests -p 'test_wave2_config_scaffolding.py' -v`
- [x] `PYTHONPATH=src python3 -m unittest discover -s tests -p 'test_validators.py' -v`

## Merge order / rebase gate
- merge PR #16 first
- rebase this branch onto latest `main` after PR #16 merges, then re-run the tests above before final merge

Made with [Cursor](https://cursor.com)