### PR TITLE
Issue #4: add complexification with semantic-preservation checks

### DIFF
--- a/src/simula_research/complexification.py
+++ b/src/simula_research/complexification.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+def _token_set(text: str) -> set[str]:
+    return set(re.findall(r"[a-z0-9]+", text.lower()))
+
+
+def _token_overlap_ratio(left: str, right: str) -> float:
+    left_tokens = _token_set(left)
+    right_tokens = _token_set(right)
+    if not left_tokens or not right_tokens:
+        return 0.0
+    denominator = min(len(left_tokens), len(right_tokens))
+    if denominator == 0:
+        return 0.0
+    return len(left_tokens.intersection(right_tokens)) / denominator
+
+
+def _complexify_text(source_text: str, strategy: str) -> str:
+    if strategy == "append_reasoning":
+        return (
+            f"{source_text} Include a multi-step justification, evaluate one plausible distractor, "
+            "and articulate why the final decision resolves ambiguity."
+        )
+    if strategy == "semantic_drift_probe":
+        return "Compute prime factorization of 163 and explain each arithmetic step."
+    raise ValueError(f"Unsupported complexification strategy: {strategy}")
+
+
+def apply_complexification(
+    samples: list[dict[str, Any]],
+    complexify_fraction: float = 0.5,
+    semantic_overlap_threshold: float = 0.55,
+    strategy: str = "append_reasoning",
+) -> dict[str, Any]:
+    if complexify_fraction < 0 or complexify_fraction > 1:
+        raise ValueError("complexify_fraction must be between 0 and 1")
+
+    target_count = int(round(len(samples) * complexify_fraction))
+    complexified: list[dict[str, Any]] = []
+    semantic_failures: list[dict[str, Any]] = []
+
+    for idx, sample in enumerate(samples):
+        source_text = sample["text"]
+        should_complexify = idx < target_count
+        if not should_complexify:
+            untouched = {
+                **sample,
+                "is_complexified": False,
+                "complexity_source": "original",
+                "source_intent": source_text,
+            }
+            complexified.append(untouched)
+            continue
+
+        transformed_text = _complexify_text(source_text, strategy=strategy)
+        overlap = _token_overlap_ratio(source_text, transformed_text)
+        if overlap < semantic_overlap_threshold:
+            semantic_failures.append(
+                {
+                    "instantiation_id": sample["instantiation_id"],
+                    "taxonomy_node_id": sample["taxonomy_node_id"],
+                    "meta_prompt_id": sample["meta_prompt_id"],
+                    "reason": "semantic_preservation_failed",
+                    "source_intent": source_text,
+                    "candidate_text": transformed_text,
+                    "semantic_overlap_ratio": overlap,
+                }
+            )
+            fallback = {
+                **sample,
+                "is_complexified": False,
+                "complexity_source": "fallback_original_due_to_semantic_failure",
+                "source_intent": source_text,
+            }
+            complexified.append(fallback)
+            continue
+
+        transformed = {
+            **sample,
+            "text": transformed_text,
+            "is_complexified": True,
+            "complexity_source": "complexification_transform_v1",
+            "source_intent": source_text,
+        }
+        complexified.append(transformed)
+
+    return {
+        "samples": complexified,
+        "complexification_policy": {
+            "complexify_fraction": complexify_fraction,
+            "semantic_overlap_threshold": semantic_overlap_threshold,
+            "strategy": strategy,
+        },
+        "semantic_preservation_failures": semantic_failures,
+    }

--- a/src/simula_research/pipeline.py
+++ b/src/simula_research/pipeline.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+from simula_research.complexification import apply_complexification
 from simula_research.local_diversification import build_local_diversification
 from simula_research.manifest import validate_manifest
 from simula_research.taxonomy import TaxonomyConfig, build_taxonomy
@@ -75,12 +76,32 @@ def _persist_local_diversification_artifacts(
     }
 
 
+def _persist_complexification_artifacts(run_root: Path, complexification: dict[str, Any]) -> dict[str, str]:
+    complex_dir = run_root / "30_complexification"
+    complex_dir.mkdir(parents=True, exist_ok=True)
+
+    samples_path = complex_dir / "samples.json"
+    failures_path = complex_dir / "semantic_preservation_failures.json"
+
+    samples_path.write_text(json.dumps(complexification["samples"], indent=2, sort_keys=True), encoding="utf-8")
+    failures_path.write_text(
+        json.dumps(complexification["semantic_preservation_failures"], indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    return {
+        "samples": str(samples_path),
+        "semantic_preservation_failures": str(failures_path),
+    }
+
+
 def run_pipeline(
     seed: int,
     model_ids: dict[str, str],
     domain_objective: str = "pilot-domain",
     artifact_root: str | Path = "artifacts/runs",
     taxonomy_config: dict[str, int] | None = None,
+    complexification_config: dict[str, Any] | None = None,
 ) -> dict[str, object]:
     run_id = f"run-{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}-{uuid4().hex[:8]}"
 
@@ -112,6 +133,16 @@ def run_pipeline(
     local_artifacts = _persist_local_diversification_artifacts(
         run_root=run_root, local_diversification=local_diversification
     )
+    complex_cfg = complexification_config or {}
+    complexification = apply_complexification(
+        samples=local_diversification["instantiations"],
+        complexify_fraction=float(complex_cfg.get("complexify_fraction", 0.5)),
+        semantic_overlap_threshold=float(complex_cfg.get("semantic_overlap_threshold", 0.55)),
+        strategy=str(complex_cfg.get("strategy", "append_reasoning")),
+    )
+    complex_artifacts = _persist_complexification_artifacts(
+        run_root=run_root, complexification=complexification
+    )
 
     stage_outputs["stage_1_global_diversification"] = {
         "status": "completed",
@@ -141,6 +172,16 @@ def run_pipeline(
         "rejection_count": len(local_diversification["rejections"]),
         "anti_collapse_checks": local_diversification["anti_collapse_checks"],
         "local_diversification_artifacts": local_artifacts,
+    }
+    stage_outputs["stage_3_complexification"] = {
+        "status": "completed",
+        "run_id": run_id,
+        "complexified_count": len(
+            [sample for sample in complexification["samples"] if sample["is_complexified"]]
+        ),
+        "semantic_preservation_failure_count": len(complexification["semantic_preservation_failures"]),
+        "complexification_policy": complexification["complexification_policy"],
+        "complexification_artifacts": complex_artifacts,
     }
 
     return {"manifest": manifest, "stage_outputs": stage_outputs, "taxonomy": taxonomy}

--- a/tests/test_issue1_tracer_bullet.py
+++ b/tests/test_issue1_tracer_bullet.py
@@ -43,6 +43,9 @@ class Issue1TracerBulletTest(unittest.TestCase):
             elif stage_name == "stage_2_local_diversification":
                 self.assertEqual(stage_output["status"], "completed")
                 self.assertTrue(stage_output["anti_collapse_checks"]["executed"])
+            elif stage_name == "stage_3_complexification":
+                self.assertEqual(stage_output["status"], "completed")
+                self.assertIn("complexification_policy", stage_output)
             else:
                 self.assertEqual(stage_output["status"], "placeholder")
 

--- a/tests/test_issue4_complexification.py
+++ b/tests/test_issue4_complexification.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from simula_research.complexification import apply_complexification
+from simula_research.pipeline import run_pipeline
+
+
+class Issue4ComplexificationTest(unittest.TestCase):
+    def test_complexification_applies_fraction_and_preserves_lineage(self) -> None:
+        samples = [
+            {
+                "instantiation_id": "inst-1",
+                "taxonomy_node_id": "tax-a",
+                "meta_prompt_id": "mp-a",
+                "lineage": {
+                    "taxonomy_node_id": "tax-a",
+                    "meta_prompt_id": "mp-a",
+                    "instantiation_id": "inst-1",
+                },
+                "text": "Classify account takeover incidents with clear evidence.",
+            },
+            {
+                "instantiation_id": "inst-2",
+                "taxonomy_node_id": "tax-b",
+                "meta_prompt_id": "mp-b",
+                "lineage": {
+                    "taxonomy_node_id": "tax-b",
+                    "meta_prompt_id": "mp-b",
+                    "instantiation_id": "inst-2",
+                },
+                "text": "Escalate suspicious card transaction patterns.",
+            },
+            {
+                "instantiation_id": "inst-3",
+                "taxonomy_node_id": "tax-c",
+                "meta_prompt_id": "mp-c",
+                "lineage": {
+                    "taxonomy_node_id": "tax-c",
+                    "meta_prompt_id": "mp-c",
+                    "instantiation_id": "inst-3",
+                },
+                "text": "Audit policy exceptions for payment disputes.",
+            },
+            {
+                "instantiation_id": "inst-4",
+                "taxonomy_node_id": "tax-d",
+                "meta_prompt_id": "mp-d",
+                "lineage": {
+                    "taxonomy_node_id": "tax-d",
+                    "meta_prompt_id": "mp-d",
+                    "instantiation_id": "inst-4",
+                },
+                "text": "Review merchant onboarding for compliance gaps.",
+            },
+        ]
+        result = apply_complexification(samples=samples, complexify_fraction=0.5)
+
+        self.assertEqual(len(result["samples"]), 4)
+        complexified = [sample for sample in result["samples"] if sample["is_complexified"]]
+        self.assertEqual(len(complexified), 2)
+        for sample in result["samples"]:
+            self.assertEqual(sample["lineage"]["taxonomy_node_id"], sample["taxonomy_node_id"])
+            self.assertEqual(sample["lineage"]["meta_prompt_id"], sample["meta_prompt_id"])
+            self.assertIn("complexity_source", sample)
+        self.assertEqual(result["complexification_policy"]["strategy"], "append_reasoning")
+
+    def test_semantic_preservation_failures_are_recorded_for_analysis(self) -> None:
+        samples = [
+            {
+                "instantiation_id": "inst-1",
+                "taxonomy_node_id": "tax-a",
+                "meta_prompt_id": "mp-a",
+                "lineage": {
+                    "taxonomy_node_id": "tax-a",
+                    "meta_prompt_id": "mp-a",
+                    "instantiation_id": "inst-1",
+                },
+                "text": "Resolve abnormal payroll transfer requests.",
+            }
+        ]
+        result = apply_complexification(
+            samples=samples,
+            complexify_fraction=1.0,
+            semantic_overlap_threshold=0.6,
+            strategy="semantic_drift_probe",
+        )
+
+        self.assertEqual(len(result["semantic_preservation_failures"]), 1)
+        self.assertFalse(result["samples"][0]["is_complexified"])
+        self.assertEqual(
+            result["samples"][0]["complexity_source"],
+            "fallback_original_due_to_semantic_failure",
+        )
+        self.assertEqual(
+            result["semantic_preservation_failures"][0]["taxonomy_node_id"],
+            "tax-a",
+        )
+
+    def test_pipeline_stage_3_persists_complexification_outputs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result = run_pipeline(
+                seed=13,
+                model_ids={"generator": "gpt-4.1-mini", "critic_a": "gpt-4.1", "critic_b": "gpt-4.1"},
+                domain_objective="payments disputes",
+                artifact_root=tmp_dir,
+                taxonomy_config={"max_depth": 1, "branching_factor": 1},
+                complexification_config={
+                    "complexify_fraction": 1.0,
+                    "semantic_overlap_threshold": 0.6,
+                    "strategy": "semantic_drift_probe",
+                },
+            )
+            stage_3 = result["stage_outputs"]["stage_3_complexification"]
+            self.assertEqual(stage_3["status"], "completed")
+            self.assertIn("complexification_artifacts", stage_3)
+            failures_path = Path(stage_3["complexification_artifacts"]["semantic_preservation_failures"])
+            failures_payload = json.loads(failures_path.read_text(encoding="utf-8"))
+            self.assertGreater(len(failures_payload), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement Stage 3 complexification with configurable sample fraction and strategy controls
- preserve taxonomy linkage and source intent while tagging transformed outputs
- persist semantic-preservation failures for analysis and downstream adjudication
- add focused tests for policy behavior, lineage preservation, and artifact persistence

## Validation
- `PYTHONPATH=src python3 -m unittest discover -s tests -p "test_issue4_complexification.py"`
- `PYTHONPATH=src python3 -m unittest discover -s tests -p "test_*.py"`

## Handoff
- Stage 3 outputs are persisted under `30_complexification/` for Issue #5 consumption.

Made with [Cursor](https://cursor.com)