### PR TITLE
Docs: sync wave execution and issue draft after Wave 3

### DIFF
--- a/docs/issues-draft.md
+++ b/docs/issues-draft.md
@@ -9,6 +9,9 @@ This is the working issue pack for implementation sequencing. Slices are intenti
 - Issue #1: complete on `main` (PR #12)
 - Issue #2: complete on `main` (PR #15)
 - Wave 1 support slices (prompt B/C): integrated in `main` via commits `86f9ce8` (validators) and `27e7e0c` (harness)
+- Issue #3: complete on `main` (PR #16)
+- Issue #4: complete on `main` (PR #18)
+- Issue #6 skeleton: complete on `main` (PR #19)
 
 ## Slice index
 
@@ -108,9 +111,9 @@ Generate meta-prompts and multiple within-node instantiations, then enforce loca
 
 ## Acceptance criteria
 
-- [ ] Every sample is traceable to `taxonomy_node_id` and `meta_prompt_id`.
-- [ ] Local diversity checks run before complexification.
-- [ ] Rejected low-diversity candidates are logged.
+- [x] Every sample is traceable to `taxonomy_node_id` and `meta_prompt_id`.
+- [x] Local diversity checks run before complexification.
+- [x] Rejected low-diversity candidates are logged.
 
 ---
 
@@ -125,9 +128,9 @@ Apply complexification to a controlled sample fraction while preserving source i
 
 ## Acceptance criteria
 
-- [ ] Complexification policy supports configurable fraction and strategy.
-- [ ] Complexified samples retain taxonomy linkage.
-- [ ] Semantic-preservation checks run and failures are recorded.
+- [x] Complexification policy supports configurable fraction and strategy.
+- [x] Complexified samples retain taxonomy linkage.
+- [x] Semantic-preservation checks run and failures are recorded.
 
 ---
 
@@ -159,10 +162,10 @@ Compute coverage, complexity, and quality metrics per `docs/evaluation-metrics.m
 
 ## Acceptance criteria
 
-- [ ] Coverage metrics include node ratio and depth profile.
-- [ ] Complexity metrics include calibrated score and complexity shift.
-- [ ] Quality metrics include acceptance, agreement, and regeneration burden.
-- [ ] Gate report maps thresholds to pass/fail outcomes.
+- [x] Coverage metrics include node ratio and depth profile.
+- [x] Complexity metrics include calibrated score and complexity shift.
+- [x] Quality metrics include acceptance, agreement, and regeneration burden.
+- [x] Gate report maps thresholds to pass/fail outcomes.
 
 ---
 

--- a/docs/parallel-agent-prompts.md
+++ b/docs/parallel-agent-prompts.md
@@ -12,8 +12,10 @@ Use this table as the source of truth for what is actually integrated in `main`.
 | Wave 1 | Prompt A: taxonomy stage | Issue #2, PR #15 | Complete | Taxonomy stage + tests are in `main`. |
 | Wave 1 | Prompt B: harness support | PR #13 (+ commit `27e7e0c` integration) | Complete | Harness fixtures/assertions and integration notes are now in `main`. |
 | Wave 1 | Prompt C: validator utilities | PR #14 (+ commit `86f9ce8` integration) | Complete | Validator APIs and tests are now in `main`. |
-| Wave 2 | Prompt A: local diversification | Issue #3, PR #16 | In review | Merge first in Wave 2 sequence. |
-| Wave 2 | Prompt B: config scaffolding | Issue #7, PR #17 | In review | Rebase on latest `main` after PR #16 merges. |
+| Wave 2 | Prompt A: local diversification | Issue #3, PR #16 | Complete | Local diversification stage + anti-collapse tests are in `main`. |
+| Wave 2 | Prompt B: config scaffolding | Issue #7, PR #17 | Complete | Baseline/ablation config presets are in `main`. |
+| Wave 3 | Prompt A: complexification | Issue #4, PR #18 | Complete | Stage 3 complexification and semantic-preservation artifacts are in `main`. |
+| Wave 3 | Prompt B: metrics skeleton | Issue #6, PR #19 | Complete | Evaluation metric scaffolding and gate report skeleton are in `main`. |
 
 ## How to use this file
 


### PR DESCRIPTION
## Summary
- update `docs/parallel-agent-prompts.md` wave status table for merged Wave 2 and Wave 3 slices
- update `docs/issues-draft.md` verification snapshot with Issues #3/#4/#6 completion on `main`
- mark completed acceptance criteria checklists for Issues #3, #4, and #6

## Why
Keep repo planning/docs aligned with merged code so the next wave prompting starts from current reality.

Made with [Cursor](https://cursor.com)