### PR TITLE
Issue #22: sample-aware dual-critic evaluator hooks and replay tests

### DIFF
--- a/docs/agents/next-agent-handoff.md
+++ b/docs/agents/next-agent-handoff.md
@@ -33,6 +33,7 @@ Optional engineering that **does not** block declaring the cycle “complete” 
 - **#27** — `src/simula_research/stage_contracts.py`: runtime validation for Stage 1–4 handoffs; `run_pipeline` calls `validate_stage_handoffs` after adjudication; tests `tests/test_stage_contracts.py`; see `docs/pipeline-spec.md`.
 - **#28** — `src/simula_research/run_artifact_store.py`: `RunArtifactStore` protocol + `FileSystemRunArtifactStore`; `run_pipeline(..., artifact_store_factory=...)`.
 - **#29** — `src/simula_research/provider_protocols.py`: `CriticVerdictFn`, `hash_based_critic_verdict`; `adjudicate_samples(..., critic_verdict=...)` and `run_pipeline(..., critic_verdict=...)`.
+- **#22** (GitHub — productionize dual-critic evaluators) — `CriticSampleEvaluatorFn`, `sample_evaluator_from_text_fn`, `recorded_sample_evaluator`, and `critic_sample_evaluator=` on `adjudicate_samples` / `run_pipeline` (mutually exclusive with `critic_verdict`); Stage 4 artifact field names unchanged. Rollout: `docs/llm-validation-readiness.md` Phase 1; verify merge state on `main` in GitHub.
 - **#30** — `evaluate_comparability_gate()` in `issue9_reproducibility.py`; tests `tests/test_issue30_comparability_gate.py`.
 
 Landmark commits (historical): **`df88524`** (contracts + comparability tests), **`73a0dc9`** (artifact store + critic hook).

--- a/docs/parallel-agent-prompts.md
+++ b/docs/parallel-agent-prompts.md
@@ -22,6 +22,26 @@ Use this table as the source of truth for what is actually integrated in `main`.
 | Wave 7 | Issue #9 reproducibility hardening | Issue #9, PR #25 | Complete | Manifest validation (B0/A1/A4), baseline rerun classification, and paper-aligned hard gates are in `main`. |
 | Wave 8 | Milestone 3 extraction seams | Issues #27–#30 (closed) | Complete | Stage contracts (`stage_contracts.py`), `RunArtifactStore`, critic `critic_verdict` hook, comparability gate tests; see `docs/agents/next-agent-handoff.md`. |
 | Wave 9 | Post–M3 hardening | Issues **#31**, **#33**; PRs **#32**, **#34** (merged) | Complete | TypedDict exports on stage handoff contracts; `REQUIRED_ARTIFACT_STAGES` aligned to `40_dual_critic_quality/` + reproducibility-ops migration note. |
+| Wave 10 | LLM validation — Stage 4 seam | GitHub **#22**; follow-ons **#41** (Phase 1.3 metadata), **#42** (Phase 3 execution fidelity) | In progress / planned | Sample-aware `CriticSampleEvaluatorFn` + replay helpers; next: provider metadata (#41), preset→pipeline behavior (#42), optional reference adapter + smoke run. |
+
+### Agent prompt: Wave 10 / LLM Phase 1 (Stage 4 critics)
+
+```text
+Read docs/llm-validation-readiness.md (Phase 1) and docs/agents/next-agent-handoff.md.
+
+Goals:
+1) Land or extend GitHub #22: provider-facing `CriticSampleEvaluatorFn` usage, deterministic replay path, and tests that keep Issue #6 quality metrics + gate report wiring valid.
+2) Add the smallest optional reference adapter (e.g. env-driven HTTP call) OR document how operators inject their own adapter without committing vendor SDKs to CI.
+3) Open/follow follow-on issues for Phase 1.3 (structured provider metadata on manifest / stage outputs) and Phase 3 (preset toggles alter execution, not only Issue #7 reporting).
+
+Constraints:
+- Do not change DEFAULT_THRESHOLDS, metric formulas, or ADR 0003 protocol semantics without ADR impact notes.
+- Preserve Stage 4 JSON artifact schemas and `40_dual_critic_quality/` layout per reproducibility-ops.
+
+Deliverables:
+- Code + tests (unittest); Paper Alignment Check on the PR.
+- Short smoke-run notes template (cost, retries, timeouts) when a real provider is used.
+```
 
 ## How to use this file
 

--- a/src/simula_research/dual_critic.py
+++ b/src/simula_research/dual_critic.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from simula_research.provider_protocols import CriticVerdict, CriticVerdictFn, hash_based_critic_verdict
+from simula_research.provider_protocols import (
+    CriticSampleEvaluatorFn,
+    CriticVerdict,
+    CriticVerdictFn,
+    hash_based_critic_verdict,
+    sample_evaluator_from_text_fn,
+)
 
 
 def _normalized_policy(policy: dict[str, Any] | None) -> dict[str, Any]:
@@ -20,15 +26,31 @@ def _normalized_policy(policy: dict[str, Any] | None) -> dict[str, Any]:
     }
 
 
+def _resolve_sample_evaluator(
+    critic_verdict: CriticVerdictFn | None,
+    critic_sample_evaluator: CriticSampleEvaluatorFn | None,
+) -> Callable[[dict[str, Any], str], CriticVerdict]:
+    if critic_sample_evaluator is not None and critic_verdict is not None:
+        raise ValueError(
+            "Pass only one of critic_sample_evaluator (sample-aware, GitHub #22) "
+            "or critic_verdict (text-only, Issue #29)"
+        )
+    if critic_sample_evaluator is not None:
+        return critic_sample_evaluator
+    text_fn = critic_verdict or hash_based_critic_verdict
+    return sample_evaluator_from_text_fn(text_fn)
+
+
 def adjudicate_samples(
     samples: list[dict[str, Any]],
     policy: dict[str, Any] | None = None,
     critic_verdict: CriticVerdictFn | None = None,
+    critic_sample_evaluator: CriticSampleEvaluatorFn | None = None,
 ) -> dict[str, Any]:
     adjudication_policy = _normalized_policy(policy)
     disagreement_policy = adjudication_policy["disagreement_policy"]
     max_regenerations = adjudication_policy["max_regenerations_per_sample"]
-    decide: Callable[[str, str], CriticVerdict] = critic_verdict or hash_based_critic_verdict
+    decide = _resolve_sample_evaluator(critic_verdict, critic_sample_evaluator)
 
     decisions: list[dict[str, Any]] = []
     rejections: list[dict[str, Any]] = []
@@ -41,8 +63,8 @@ def adjudicate_samples(
         meta_prompt_id = str(sample.get("meta_prompt_id", "unknown-meta"))
         source_text = str(sample.get("text", ""))
         regen_count = 0
-        critic_a_decision = decide(source_text, "critic_a")
-        critic_b_decision = decide(source_text, "critic_b")
+        critic_a_decision = decide(sample, "critic_a")
+        critic_b_decision = decide(sample, "critic_b")
 
         if critic_a_decision == critic_b_decision:
             final_status = "accepted" if critic_a_decision == "accept" else "rejected"
@@ -60,8 +82,9 @@ def adjudicate_samples(
             for regeneration_index in range(max_regenerations):
                 regen_count += 1
                 regen_text = f"{regen_text} [regen-{regeneration_index + 1}]"
-                regen_a_decision = decide(regen_text, "critic_a")
-                regen_b_decision = decide(regen_text, "critic_b")
+                regen_sample = {**sample, "text": regen_text}
+                regen_a_decision = decide(regen_sample, "critic_a")
+                regen_b_decision = decide(regen_sample, "critic_b")
                 regenerations.append(
                     {
                         "instantiation_id": sample_id,

--- a/src/simula_research/pipeline.py
+++ b/src/simula_research/pipeline.py
@@ -10,7 +10,7 @@ from simula_research.complexification import apply_complexification
 from simula_research.dual_critic import adjudicate_samples
 from simula_research.local_diversification import build_local_diversification
 from simula_research.manifest import validate_manifest
-from simula_research.provider_protocols import CriticVerdictFn
+from simula_research.provider_protocols import CriticSampleEvaluatorFn, CriticVerdictFn
 from simula_research.run_artifact_store import FileSystemRunArtifactStore, RunArtifactStore
 from simula_research.stage_contracts import validate_stage_handoffs
 from simula_research.taxonomy import TaxonomyConfig, build_taxonomy
@@ -38,6 +38,7 @@ def run_pipeline(
     dual_critic_config: dict[str, Any] | None = None,
     artifact_store_factory: Callable[[Path], RunArtifactStore] | None = None,
     critic_verdict: CriticVerdictFn | None = None,
+    critic_sample_evaluator: CriticSampleEvaluatorFn | None = None,
 ) -> dict[str, object]:
     run_id = f"run-{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}-{uuid4().hex[:8]}"
 
@@ -77,10 +78,16 @@ def run_pipeline(
         strategy=str(complex_cfg.get("strategy", "append_reasoning")),
     )
     complex_artifacts = store.persist_complexification(complexification)
+    if critic_verdict is not None and critic_sample_evaluator is not None:
+        raise ValueError(
+            "run_pipeline: pass only one of critic_sample_evaluator (GitHub #22) "
+            "or critic_verdict (Issue #29)"
+        )
     adjudication = adjudicate_samples(
         samples=complexification["samples"],
         policy=dual_critic_config,
         critic_verdict=critic_verdict,
+        critic_sample_evaluator=critic_sample_evaluator,
     )
     validate_stage_handoffs(
         taxonomy=taxonomy,

--- a/src/simula_research/provider_protocols.py
+++ b/src/simula_research/provider_protocols.py
@@ -1,18 +1,61 @@
 from __future__ import annotations
 
 import hashlib
-from typing import Literal, Protocol
+from collections.abc import Mapping
+from typing import Any, Literal, Protocol
 
 CriticVerdict = Literal["accept", "reject"]
 
 
 class CriticVerdictFn(Protocol):
-    """Callable used by dual-critic adjudication (Issue #29); swap for tests or real providers."""
+    """Callable used by dual-critic adjudication (Issue #29); swap for tests or legacy text-only hooks."""
 
     def __call__(self, text: str, critic_id: str) -> CriticVerdict: ...
+
+
+class CriticSampleEvaluatorFn(Protocol):
+    """Provider-facing hook (GitHub #22): full Stage-3 sample dict + critic id → verdict.
+
+    Use this for LLM-backed critics that need lineage fields (`instantiation_id`, taxonomy ids,
+    `is_complexified`, …). Stage 4 on-disk JSON schema is unchanged; only the decision source differs.
+    """
+
+    def __call__(self, sample: dict[str, Any], critic_id: str) -> CriticVerdict: ...
 
 
 def hash_based_critic_verdict(text: str, critic_id: str) -> CriticVerdict:
     """Deterministic stub matching historical `dual_critic._decision_from_text` behavior."""
     digest = hashlib.sha1(f"{critic_id}::{text}".encode("utf-8")).hexdigest()
     return "accept" if int(digest[:2], 16) % 2 == 0 else "reject"
+
+
+def sample_evaluator_from_text_fn(fn: CriticVerdictFn) -> CriticSampleEvaluatorFn:
+    """Wrap a text-only verdict function as a sample evaluator (replay / parity with Issue #29)."""
+
+    def evaluate(sample: dict[str, Any], critic_id: str) -> CriticVerdict:
+        return fn(str(sample.get("text", "")), critic_id)
+
+    return evaluate
+
+
+def recorded_sample_evaluator(
+    table: Mapping[tuple[str, str, str], CriticVerdict],
+) -> CriticSampleEvaluatorFn:
+    """Deterministic replay: map (instantiation_id, critic_id, text) → verdict.
+
+    Intended for reruns that must match a prior provider-backed session without calling APIs again.
+    """
+    frozen = dict(table)
+
+    def evaluate(sample: dict[str, Any], critic_id: str) -> CriticVerdict:
+        key = (
+            str(sample.get("instantiation_id", "unknown-sample")),
+            critic_id,
+            str(sample.get("text", "")),
+        )
+        if key not in frozen:
+            msg = f"recorded_sample_evaluator: missing verdict for {key!r}"
+            raise KeyError(msg)
+        return frozen[key]
+
+    return evaluate

--- a/tests/test_issue22_dual_critic_evaluators.py
+++ b/tests/test_issue22_dual_critic_evaluators.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+from simula_research.dual_critic import adjudicate_samples
+from simula_research.evaluation_metrics import build_gate_report, compute_quality_metrics
+from simula_research.pipeline import run_pipeline
+from simula_research.provider_protocols import (
+    hash_based_critic_verdict,
+    recorded_sample_evaluator,
+    sample_evaluator_from_text_fn,
+)
+
+
+class Issue22DualCriticEvaluatorsTests(unittest.TestCase):
+    def test_sample_evaluator_wrapped_hash_matches_default_adjudication(self) -> None:
+        samples = [
+            {
+                "instantiation_id": "a",
+                "taxonomy_node_id": "t1",
+                "meta_prompt_id": "m1",
+                "text": "hello",
+                "is_complexified": True,
+            },
+            {
+                "instantiation_id": "b",
+                "taxonomy_node_id": "t2",
+                "meta_prompt_id": "m2",
+                "text": "world",
+                "is_complexified": False,
+            },
+        ]
+        default_adj = adjudicate_samples(samples=samples, policy={"disagreement_policy": "reject"})
+        wrapped_adj = adjudicate_samples(
+            samples=samples,
+            policy={"disagreement_policy": "reject"},
+            critic_sample_evaluator=sample_evaluator_from_text_fn(hash_based_critic_verdict),
+        )
+        self.assertEqual(default_adj["decisions"], wrapped_adj["decisions"])
+        self.assertEqual(default_adj["accepted_samples"], wrapped_adj["accepted_samples"])
+        self.assertEqual(default_adj["rejection_log"], wrapped_adj["rejection_log"])
+
+    def test_recorded_sample_evaluator_is_stable_replay(self) -> None:
+        sample = {
+            "instantiation_id": "inst-x",
+            "taxonomy_node_id": "tax-x",
+            "meta_prompt_id": "mp-x",
+            "text": "fixed-text",
+        }
+        table: dict[tuple[str, str, str], str] = {
+            ("inst-x", "critic_a", "fixed-text"): "accept",
+            ("inst-x", "critic_b", "fixed-text"): "accept",
+        }
+        first = adjudicate_samples(samples=[sample], critic_sample_evaluator=recorded_sample_evaluator(table))
+        second = adjudicate_samples(samples=[sample], critic_sample_evaluator=recorded_sample_evaluator(table))
+        self.assertEqual(first, second)
+        self.assertEqual(first["decisions"][0]["critic_a_decision"], "accept")
+        self.assertEqual(first["decisions"][0]["quality_status"], "accepted")
+
+    def test_sample_evaluator_receives_regenerated_text_in_sample(self) -> None:
+        seen_texts: list[str] = []
+
+        def capture(sample: dict[str, Any], critic_id: str) -> str:
+            seen_texts.append(f"{critic_id}:{sample.get('text', '')}")
+            return "accept" if critic_id == "critic_a" else "reject"
+
+        sample = {
+            "instantiation_id": "r1",
+            "taxonomy_node_id": "t1",
+            "meta_prompt_id": "m1",
+            "text": "base",
+        }
+        adjudicate_samples(
+            samples=[sample],
+            policy={"disagreement_policy": "regenerate", "max_regenerations_per_sample": 1},
+            critic_sample_evaluator=capture,
+        )
+        self.assertTrue(any("[regen-1]" in entry for entry in seen_texts))
+
+    def test_both_evaluator_hooks_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+
+            def _t(_text: str, _cid: str) -> str:
+                return "accept"
+
+            def _s(_sample: dict[str, Any], _cid: str) -> str:
+                return "accept"
+
+            adjudicate_samples(
+                samples=[
+                    {
+                        "instantiation_id": "i",
+                        "taxonomy_node_id": "t",
+                        "meta_prompt_id": "m",
+                        "text": "x",
+                    }
+                ],
+                critic_verdict=_t,
+                critic_sample_evaluator=_s,
+            )
+
+    def test_pipeline_sample_evaluator_issue6_quality_and_gate_report(self) -> None:
+        def accept_complexified_only(sample: dict[str, Any], critic_id: str) -> str:
+            if bool(sample.get("is_complexified")):
+                return "accept"
+            return "reject"
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result = run_pipeline(
+                seed=42,
+                model_ids={"generator": "g", "critic_a": "a", "critic_b": "b"},
+                domain_objective="pilot-domain",
+                artifact_root=tmp_dir,
+                taxonomy_config={"max_depth": 1, "branching_factor": 2},
+                dual_critic_config={"disagreement_policy": "reject"},
+                critic_sample_evaluator=accept_complexified_only,
+            )
+
+            stage4 = result["stage_outputs"]["stage_4_dual_critic_quality_verification"]
+            self.assertEqual(stage4["status"], "completed")
+
+            decisions_path = Path(stage4["stage4_artifacts"]["critic_decisions"])
+            decisions = json.loads(decisions_path.read_text(encoding="utf-8"))
+            for row in decisions:
+                self.assertIn("critic_a_decision", row)
+                self.assertIn("critic_b_decision", row)
+                self.assertIn("quality_status", row)
+
+            quality = compute_quality_metrics(issue5_outputs=stage4)
+            self.assertFalse(quality["requires_issue_5_outputs"])
+            self.assertIsNotNone(quality["acceptance_rate"])
+            self.assertIsNotNone(quality["critic_agreement"])
+
+            gate = build_gate_report(
+                run_identity={"run_id": result["manifest"]["run_id"], "seed": 42},
+                protocol={"critic_adjudication_config": {"mode": "dual_critic"}},
+                coverage_metrics={"node_coverage_ratio": 0.9, "depth_coverage_profile": {"0": 0.9}},
+                complexity_metrics={"complexification_precision": 0.8},
+                quality_metrics=quality,
+            )
+            self.assertIn("gate_decision", gate)
+            self.assertIn("quality", gate)
+
+    def test_run_pipeline_rejects_both_critic_hooks(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self.assertRaises(ValueError):
+                run_pipeline(
+                    seed=1,
+                    model_ids={"generator": "g", "critic_a": "a", "critic_b": "b"},
+                    artifact_root=tmp_dir,
+                    taxonomy_config={"max_depth": 1, "branching_factor": 2},
+                    critic_verdict=hash_based_critic_verdict,
+                    critic_sample_evaluator=sample_evaluator_from_text_fn(hash_based_critic_verdict),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Reconciles and formalizes the local/agent changes for GitHub issue #22 by introducing a sample-aware Stage 4 evaluator hook path while preserving existing artifact contracts.

## What changed
- `provider_protocols.py`
  - adds `CriticSampleEvaluatorFn`
  - adds `sample_evaluator_from_text_fn(...)` adapter
  - adds `recorded_sample_evaluator(...)` for deterministic replay
- `dual_critic.py`
  - `adjudicate_samples(...)` now accepts `critic_sample_evaluator=`
  - enforces mutual exclusivity between `critic_verdict` and `critic_sample_evaluator`
  - regeneration path evaluates updated sample text (`[regen-n]`) via sample-aware evaluator
- `pipeline.py`
  - `run_pipeline(...)` now accepts `critic_sample_evaluator=` and forwards it to adjudication
  - mutual exclusivity guard at pipeline boundary
- `tests/test_issue22_dual_critic_evaluators.py`
  - parity with default hash path via wrapper
  - deterministic replay behavior
  - regen text visibility in evaluator input
  - guard tests for dual-hook rejection
  - quality/gate-report compatibility smoke via pipeline
- docs touch-ups in handoff/prompts for Wave 10 references

## Validation
- `PYTHONPATH=src python3 -m unittest discover -s tests -v` (58 tests, all passing)

## Follow-ons
- #41: persist provider metadata in run artifacts/manifests
- #42: ensure `pipeline_config` toggles alter execution semantics (not only reporting)

## Paper Alignment Check
- **Traceability/Auditability:** Stage 4 artifact schema and `40_dual_critic_quality` path stay unchanged; replay helper improves auditability for provider-backed reruns.
- **Protocol/Comparability:** No threshold/metric formula/ablation definition changes; ADR 0003 semantics preserved.
- **Control-Axis Impact:** Changes are scoped to quality-evaluator injection seam; coverage/complexity pathways unchanged.
- **Deviation Log:** none.

Refs: #22

Made with [Cursor](https://cursor.com)