### PR TITLE
LLM validation readiness: #22 sample evaluator, #41 runtime metadata, #42 execution fidelity

### DIFF
--- a/artifacts/reports/issue8/milestone_gate_review.json
+++ b/artifacts/reports/issue8/milestone_gate_review.json
@@ -79,7 +79,9 @@
         "classification": "exact",
         "drift_threshold": 0.02,
         "max_metric_delta": 0.0,
-        "rerun_matrix_root": "artifacts/reports/issue9/issue7/20260509T160651Z"
+        "metric_paths_compared": 17,
+        "missing_metric_paths": [],
+        "rerun_matrix_root": "artifacts/reports/issue9/issue7/20260526T013107Z"
       },
       "blocked_by_issue": null,
       "comparability_constraints": "unchanged",
@@ -91,7 +93,7 @@
           "ok": true
         },
         "fixed_protocol_comparability": {
-          "details": "Comparability constraints pass, with mixed axes limited to documented ablation design.",
+          "details": "Comparability constraints pass; any mixed axes declare mixed_reason=documented_ablation.",
           "ok": true
         },
         "reproducibility": {
@@ -107,9 +109,9 @@
             "manifest": {
               "artifact_schema_version": "v1",
               "baseline_or_ablation_tag": "A1",
-              "branch": "feature/issue-7-execute-b0-a1-a4",
-              "commit_hash": "5d631a8",
-              "created_at_utc": "2026-04-30T20:47:44.068750+00:00",
+              "branch": "feature/llm-validation-issues-22-41-42",
+              "commit_hash": "70a79c215e5e23db2c121bb5b68a9ee12fbe81a9",
+              "created_at_utc": "2026-05-26T01:26:40.828949+00:00",
               "domain_objective": "pilot-domain",
               "model_ids": {
                 "critic_a": "gpt-4.1",
@@ -124,7 +126,7 @@
                 "local_diversification_enabled": true
               },
               "protocol_version": "0.1.0",
-              "run_id": "run-20260430T204744Z-60679fdb",
+              "run_id": "run-20260526T012640Z-8befe738",
               "seed": 7
             },
             "ok": true
@@ -134,9 +136,9 @@
             "manifest": {
               "artifact_schema_version": "v1",
               "baseline_or_ablation_tag": "A4",
-              "branch": "feature/issue-7-execute-b0-a1-a4",
-              "commit_hash": "5d631a8",
-              "created_at_utc": "2026-04-30T20:47:44.072523+00:00",
+              "branch": "feature/llm-validation-issues-22-41-42",
+              "commit_hash": "70a79c215e5e23db2c121bb5b68a9ee12fbe81a9",
+              "created_at_utc": "2026-05-26T01:26:40.831680+00:00",
               "domain_objective": "pilot-domain",
               "model_ids": {
                 "critic_a": "gpt-4.1",
@@ -152,7 +154,7 @@
                 "single_critic_mode": "critic_a"
               },
               "protocol_version": "0.1.0",
-              "run_id": "run-20260430T204744Z-d386f9b4",
+              "run_id": "run-20260526T012640Z-c7154678",
               "seed": 7
             },
             "ok": true
@@ -162,9 +164,9 @@
             "manifest": {
               "artifact_schema_version": "v1",
               "baseline_or_ablation_tag": "B0",
-              "branch": "feature/issue-7-execute-b0-a1-a4",
-              "commit_hash": "5d631a8",
-              "created_at_utc": "2026-04-30T20:47:44.064727+00:00",
+              "branch": "feature/llm-validation-issues-22-41-42",
+              "commit_hash": "70a79c215e5e23db2c121bb5b68a9ee12fbe81a9",
+              "created_at_utc": "2026-05-26T01:26:40.826586+00:00",
               "domain_objective": "pilot-domain",
               "model_ids": {
                 "critic_a": "gpt-4.1",
@@ -179,7 +181,7 @@
                 "local_diversification_enabled": true
               },
               "protocol_version": "0.1.0",
-              "run_id": "run-20260430T204744Z-d55fde55",
+              "run_id": "run-20260526T012640Z-374e09a1",
               "seed": 7
             },
             "ok": true
@@ -188,7 +190,7 @@
       },
       "paper_alignment": {
         "control_axis_interpretability": "Coverage/complexity/quality axes are interpreted only under fixed protocol and reproducible rerun evidence.",
-        "fixed_protocol_comparability": "Comparability constraints pass, with mixed axes limited to documented ablation design.",
+        "fixed_protocol_comparability": "Comparability constraints pass; any mixed axes declare mixed_reason=documented_ablation.",
         "traceability_auditability": "Audit traces include comparison tables, per-run gate reports, run IDs, and reconstructed manifests."
       },
       "status": "exact",
@@ -204,11 +206,11 @@
       "B0": "run-20260430T204744Z-d55fde55"
     },
     "sources": {
-      "comparison_tables": "artifacts/reports/issue7/20260430T204744Z/comparison_tables.json",
+      "comparison_tables": "artifacts/reports/issue7/20260526T012640Z/comparison_tables.json",
       "gate_reports": [
-        "artifacts/reports/issue7/20260430T204744Z/B0/gate_report.json",
-        "artifacts/reports/issue7/20260430T204744Z/A1/gate_report.json",
-        "artifacts/reports/issue7/20260430T204744Z/A4/gate_report.json"
+        "artifacts/reports/issue7/20260526T012640Z/B0/gate_report.json",
+        "artifacts/reports/issue7/20260526T012640Z/A1/gate_report.json",
+        "artifacts/reports/issue7/20260526T012640Z/A4/gate_report.json"
       ]
     }
   },
@@ -228,7 +230,7 @@
   },
   "review_metadata": {
     "decision": "fail",
-    "evidence_packet": "artifacts/reports/issue7/20260430T204744Z",
+    "evidence_packet": "artifacts/reports/issue7/20260526T012640Z",
     "issue_id": 8,
     "review_scope_constraints": [
       "No Issue #9 implementation in this review",
@@ -239,10 +241,10 @@
     "review_type": "milestone-1-hitl-gate-review"
   },
   "threshold_adjustment_recommendation": {
-    "adr_note": "No ADR trigger in Issue #8 because no threshold value change is proposed. If thresholds are revised after Issue #9 reproducibility and follow-on diagnosis, open an ADR documenting trade-offs.",
+    "adr_note": "Safe alternative: maintain existing thresholds until hard gates pass.",
     "adr_required": false,
     "proposed_changes": [],
-    "rationale": "Observed misses are large and systematic. Lowering thresholds now would reduce gate discrimination instead of addressing pipeline bottlenecks.",
+    "rationale": "Rejected threshold tuning because Issue #9 hard gates are not all satisfied. Resolve reproducibility, audit-trace, and comparability evidence first.",
     "recommendation": "keep_thresholds_as_is"
   },
   "threshold_mapping": [

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ This folder is organized around "what is active now" vs "reference material".
 - [`evaluation-metrics.md`](./evaluation-metrics.md): coverage, complexity, and quality metrics
 - [`reproducibility-ops.md`](./reproducibility-ops.md): manifest and rerun protocol guidance
 - [`research-validation-playbook.md`](./research-validation-playbook.md): baseline and ablation operating playbook
+- [`llm-validation-readiness.md`](./llm-validation-readiness.md): real-LLM rollout checklist, env wiring, and phase plan
 
 ## Governance
 

--- a/docs/agents/next-agent-handoff.md
+++ b/docs/agents/next-agent-handoff.md
@@ -94,7 +94,7 @@ Regenerating runs: use `run_pipeline` / Issue #7 tooling; new runs land under `a
 
 ### P1 — Strongly recommended before real LLM integration
 
-2. **Sample-aware critic + execution fidelity + metadata (implemented together — verify PR / branch before relying on `main`)**  
+2. **Sample-aware critic + execution fidelity + metadata** — **PR [#45](https://github.com/AtulyaK/simula-research/pull/45)** (`feature/llm-validation-issues-22-41-42`); merge before relying on `main`.  
    - **#22** `CriticSampleEvaluatorFn` + `sample_evaluator_from_text_fn` / `recorded_sample_evaluator`; `run_pipeline(..., critic_sample_evaluator=...)` (mutually exclusive with `critic_verdict`).  
    - **#41** optional `provider_runtime` on manifest + stage 4 echo; `provider_runtime_from_env()` for operator transport metadata (no secrets).  
    - **#42** `pipeline_config` presets passed from `execute_issue7_matrix` into `run_pipeline` (A1 shallow taxonomy, A4 `single_critic_mode`, etc.); reporting-only A1/A4 metric hacks removed.  

--- a/docs/agents/next-agent-handoff.md
+++ b/docs/agents/next-agent-handoff.md
@@ -94,12 +94,18 @@ Regenerating runs: use `run_pipeline` / Issue #7 tooling; new runs land under `a
 
 ### P1 — Strongly recommended before real LLM integration
 
-2. **Generator / earlier-stage protocols**  
+2. **Sample-aware critic + execution fidelity + metadata (implemented together — verify PR / branch before relying on `main`)**  
+   - **#22** `CriticSampleEvaluatorFn` + `sample_evaluator_from_text_fn` / `recorded_sample_evaluator`; `run_pipeline(..., critic_sample_evaluator=...)` (mutually exclusive with `critic_verdict`).  
+   - **#41** optional `provider_runtime` on manifest + stage 4 echo; `provider_runtime_from_env()` for operator transport metadata (no secrets).  
+   - **#42** `pipeline_config` presets passed from `execute_issue7_matrix` into `run_pipeline` (A1 shallow taxonomy, A4 `single_critic_mode`, etc.); reporting-only A1/A4 metric hacks removed.  
+   - **Adapter:** `src/simula_research/critic_provider_adapter.py` — `SIMULA_CRITIC_BACKEND` (`stub` / `replay`), retry helper, failure logging wrapper.
+
+3. **Generator / earlier-stage protocols**  
    - **#29** only injected **critic verdict**. Taxonomy, local diversification, and complexification are still deterministic in-repo logic.  
    - **Goal:** `Protocol` + factory hooks mirroring `critic_verdict` / `artifact_store_factory`, with **bit-identical** default factories.  
    - **Tests:** Same golden outputs as current `run_pipeline` for default factories.
 
-3. **Stage 0 / manifest completeness**  
+4. **Stage 0 / manifest completeness**  
    - `manifest.validate_manifest` is **minimal** (pipeline boot).  
    - `validators.validate_manifest_schema` is the **full** reproducibility set (Issue #9).  
    - **Goal:** Document “fast boot” vs “full reproducibility” modes in code + `docs/reproducibility-ops.md`, or unify with explicit mode flag—**must** keep `tests/test_issue9_reproducibility.py` green.

--- a/docs/llm-validation-readiness.md
+++ b/docs/llm-validation-readiness.md
@@ -191,8 +191,9 @@ You are ready to run full LLM-backed validation when all are checked:
 
 - [x] baseline test suite is green (`PYTHONPATH=src python3 -m unittest discover -s tests -v`)
 - [ ] provider credentials and budget guardrails are configured (human / org policy)
-- [ ] run manifest and artifact conventions are enforced
+- [x] run manifest and artifact conventions are enforced for stage trees (`artifacts/runs/<run_id>/`); full `validate_manifest_schema` on disk requires Issue #9 fields (`created_at_utc`, `domain_objective`, …) — use `execute_issue7_matrix` or extend smoke `manifest.json` per `docs/reproducibility-ops.md`
 - [x] critic provider integration path is operational for **stub/replay** (`critic_provider_adapter`, sample evaluator seam, metadata echo); live HTTP vendors require keys and org approval
+- [x] provider-shaped smoke validated (stub backend, incident logs under `artifacts/reports/llm-smoke/`; reproducibility `exact` at gate-metric level for same seed)
 - [ ] stage 1-3 provider plan is either implemented or explicitly out-of-scope
 - [x] ablation behavior fidelity is validated at execution level (`pipeline_config` → `run_pipeline`; tests `test_issue42_pipeline_config_execution.py`)
 - [ ] reproducibility policy for stochastic drift is documented

--- a/docs/llm-validation-readiness.md
+++ b/docs/llm-validation-readiness.md
@@ -1,0 +1,207 @@
+# LLM Validation Readiness Guide
+
+## Purpose
+
+This guide explains how to make the repository ready for end-to-end validation with real LLM providers and real persisted datasets, while preserving the research protocol guardrails.
+
+Use this together with:
+
+- `docs/research_paper.pdf` (research intent and validation framing)
+- `docs/research-validation-playbook.md` (hypotheses H1-H4, B0/A1/A4 matrix, run checklist)
+- `docs/pipeline-spec.md` (stage contracts)
+- `docs/evaluation-metrics.md` (metric definitions and gates)
+- `docs/reproducibility-ops.md` (manifest/artifact/rerun protocol)
+- `docs/adr/0002-control-axes-as-first-class.md` and `docs/adr/0003-evaluation-protocol-and-thresholds.md` (non-negotiable comparability constraints)
+- `docs/agents/next-agent-handoff.md` (current project status and prioritized follow-ups)
+
+## What "ready for LLM validation" means
+
+The project is "LLM-validation ready" when all of the following are true:
+
+1. You can run baseline and ablations with explicit, versioned provider settings.
+2. Runs produce complete artifacts and manifests that can be audited and rerun.
+3. Coverage, complexity, and quality remain independent control axes.
+4. Gate decisions are made against the current metric protocol without silent formula/threshold drift.
+5. Any non-determinism from providers is handled under the reproducibility policy (exact match vs acceptable drift vs mismatch).
+
+## Current state (important before planning real runs)
+
+The codebase supports a deterministic full pipeline and milestone evidence. LLM-oriented seams are now wired as follows:
+
+- Stage 4 critic verdict is injectable in two ways (see `src/simula_research/provider_protocols.py`, `dual_critic.adjudicate_samples`, `pipeline.run_pipeline`):
+  - **`CriticVerdictFn` (Issue #29):** `(text, critic_id) -> verdict` — smallest surface; sufficient for hash stubs and text-only wrappers.
+  - **`CriticSampleEvaluatorFn` (Issue #22):** `(sample, critic_id) -> verdict` — **provider-facing** path: full Stage-3 sample dict (lineage, `is_complexified`, regenerated `text`, …) without changing Stage 4 JSON artifact field names.
+- Helpers for rollout: `sample_evaluator_from_text_fn` (parity / replay vs hash path), `recorded_sample_evaluator` (offline replay from a fixed verdict table). `critic_verdict` and `critic_sample_evaluator` are **mutually exclusive** at the pipeline boundary.
+- **Provider/runtime metadata (Issue #41):** optional `provider_runtime` dict is merged into the run `manifest` and echoed under `stage_outputs.stage_4_dual_critic_quality_verification.provider_runtime` when supplied. `provider_runtime_from_env()` in `critic_provider_adapter.py` collects **non-secret** transport knobs from environment variables for operator runs.
+- **Execution fidelity (Issue #42):** `execute_issue7_matrix` passes each preset’s `pipeline_config` into `run_pipeline`, which maps toggles to taxonomy/local/complexification/dual-critic execution (A1 shallow taxonomy, A4 `single_critic_mode`, etc.). Reporting-time metric hacks for A1/A4 have been removed; matrix metrics now reflect actual stage outputs.
+- **Env-based critic wiring:** `critic_sample_evaluator_from_env()` returns `None` (hash default), or a **non-network** `stub` / `replay` evaluator for smoke tests (`SIMULA_CRITIC_BACKEND`, `SIMULA_CRITIC_REPLAY_JSON`). See `docs/research-validation-playbook.md` for the operator snippet.
+- Stages 1–3 remain deterministic in-repo logic by default (Phase 2 of this guide).
+
+### Issue #7 matrix
+
+`src/simula_research/issue7_execution_reporting.py` passes preset `pipeline_config` into `run_pipeline` so B0/A1/A4 differ in persisted artifacts and downstream metrics without report-only adjustments.
+
+## Prerequisites Checklist
+
+## 1) Runtime and tools
+
+- Python 3.11+ (3.13 works in this repo)
+- `gh` CLI authenticated to the repository (issue/PR workflows)
+- Git configured for branch/commit traceability
+
+## 2) Provider resources
+
+- Provider accounts for target LLM vendors
+- API keys with explicit environment variable names
+- Cost controls:
+  - hard spend cap per day
+  - per-run budget target
+  - alerting threshold (for example, 50%, 80%, 100% of budget)
+- Rate-limit handling strategy:
+  - retries
+  - backoff policy
+  - max retry budget per run
+
+## 3) Data and compliance controls
+
+- Define whether prompts/responses may contain sensitive or regulated content.
+- Decide logging policy for prompt/response payloads:
+  - full text
+  - redacted text
+  - hashes only
+- Confirm retention period for raw model outputs.
+- Confirm whether model provider data usage settings satisfy your policy.
+
+## 4) Reproducibility controls
+
+- Persist complete run identity (`run_id`, seed, model IDs, protocol version, artifact schema version, commit hash, branch).
+- Persist artifacts under `artifacts/runs/<run_id>/...` following `docs/reproducibility-ops.md`.
+- Ensure stage-4 path alignment with current convention: `40_dual_critic_quality/`.
+
+## 5) Baseline repo health gate
+
+Run and pass:
+
+```bash
+PYTHONPATH=src python3 -m unittest discover -s tests -v
+```
+
+Do not start provider-backed validation until this baseline gate is green.
+
+## Concrete Rollout Plan
+
+## Phase 0 - Freeze protocol and run discipline
+
+1. Freeze pilot objective and task format.
+2. Freeze baseline/ablation set (minimum: B0, A1, A4 per playbook).
+3. Freeze evaluation protocol version and artifact schema version.
+4. Record these in a run checklist template before first provider-backed run.
+5. Confirm no threshold or metric formula changes are proposed (ADR 0003 constraint).
+
+Deliverable:
+
+- A single approved run checklist doc for this validation batch.
+
+## Phase 1 - Introduce the smallest real-LLM surface (Stage 4 critics)
+
+1. Implement production critic adapters (per critic identity **A** / **B**) behind the **`CriticSampleEvaluatorFn`** seam when the model needs full sample context; use **`CriticVerdictFn`** only when a text-only wrapper is enough, bridged via `sample_evaluator_from_text_fn` for adjudication.
+2. Keep deterministic fallback path available for debugging and reproducibility comparisons (`critic_verdict` / `critic_sample_evaluator` unset → hash-based stub; or explicit `recorded_sample_evaluator` / wrapped hash for replay).
+3. Add structured provider metadata to run outputs via optional `provider_runtime` on `run_pipeline` (manifest + stage 4 echo) and `provider_runtime_from_env()` for transport/model aliases — GitHub **#41**.
+4. Execute a small smoke run and validate that:
+   - artifacts persist,
+   - stage handoff contracts pass,
+   - gate report generation still succeeds.
+
+Deliverable:
+
+- One provider-backed smoke run with complete artifacts and a short incident log (timeouts/retries/cost).
+
+## Phase 2 - Expand provider seams to Stages 1-3 (recommended)
+
+1. Add protocol-based hooks for:
+   - taxonomy generation
+   - local diversification
+   - complexification
+2. Keep defaults bit-identical to current deterministic behavior.
+3. Add tests that prove default path remains unchanged.
+4. Document boot-vs-full manifest validation expectations if touching `manifest` and `validators`.
+
+Deliverable:
+
+- Provider seams for all generation stages with deterministic defaults preserved.
+
+## Phase 3 - Enforce true ablation behavior
+
+1. Ensure ablation presets (B0/A1/A4) change actual runtime stage behavior, not only reporting metadata — **#42** implemented via `pipeline_config` in `run_pipeline` and `execute_issue7_matrix`.
+2. Validate that run reports reflect real stage toggles and no simulated-only effects.
+3. Re-run comparison matrix and verify expected directional effects against H1-H4 framing.
+
+Deliverable:
+
+- Matrix evidence where ablation semantics are implemented in execution logic.
+
+## Phase 4 - Full validation cycle with real data
+
+1. Execute B0.
+2. Execute A1 and A4 (or full matrix if budget permits).
+3. Produce and persist:
+   - run reports,
+   - gate reports,
+   - comparison outputs,
+   - failure analysis notes.
+4. Run reproducibility classification on baseline rerun.
+5. Record milestone gate recommendation (pass/conditional pass/fail) with evidence links.
+
+Deliverable:
+
+- A complete validation packet equivalent to Issue #7/#8/#9 evidence, but provider-backed.
+
+## Resource Planning Template
+
+Before each validation batch, fill this table:
+
+| Category | Required input |
+| --- | --- |
+| Provider models | model IDs for generator, critic_a, critic_b |
+| API config | key names, endpoint, timeout, retries, backoff |
+| Budget | max total spend, per-run spend target |
+| Throughput | target samples/run, expected runtime |
+| Observability | logs, traces, failure counters |
+| Reproducibility | seed policy, protocol version, commit hash pin |
+| Governance | PII policy, retention policy, access controls |
+
+## Stop Conditions and Escalation
+
+Stop the batch and escalate if any of these occur:
+
+- repeated provider failures invalidate run completeness
+- disagreement/regeneration behavior becomes unstable and dominates quality metrics
+- reproducibility check yields mismatch without explainable provider drift
+- protocol/threshold changes are requested without ADR 0003 impact process
+
+When stopped:
+
+1. Run a focused diagnosis pass.
+2. Propose one smallest next change.
+3. Re-run only affected cells of the matrix.
+
+## Definition of Readiness (Checklist)
+
+You are ready to run full LLM-backed validation when all are checked:
+
+- [x] baseline test suite is green (`PYTHONPATH=src python3 -m unittest discover -s tests -v`)
+- [ ] provider credentials and budget guardrails are configured (human / org policy)
+- [ ] run manifest and artifact conventions are enforced
+- [x] critic provider integration path is operational for **stub/replay** (`critic_provider_adapter`, sample evaluator seam, metadata echo); live HTTP vendors require keys and org approval
+- [ ] stage 1-3 provider plan is either implemented or explicitly out-of-scope
+- [x] ablation behavior fidelity is validated at execution level (`pipeline_config` → `run_pipeline`; tests `test_issue42_pipeline_config_execution.py`)
+- [ ] reproducibility policy for stochastic drift is documented
+- [ ] Paper/ADR constraints acknowledged in run packet
+
+## Notes on thresholds and formulas
+
+This guide does not modify metric formulas, thresholds, or ablation definitions. If you need those changes:
+
+1. justify from `docs/research_paper.pdf` evidence and current run outcomes,
+2. assess impact against `docs/adr/0003-evaluation-protocol-and-thresholds.md`,
+3. update ADR/docs before applying changes in code.

--- a/docs/research-validation-playbook.md
+++ b/docs/research-validation-playbook.md
@@ -37,6 +37,44 @@ Use one domain objective at a time. Run baseline first, then ablations.
 
 If resources are limited, prioritize `B0`, `A1`, and `A4`.
 
+## Provider-backed smoke (stdlib / no live vendor keys)
+
+Use this for a **smallest viable** provider-shaped run: env-derived metadata plus the `stub` critic backend (hash parity through `sample_evaluator_from_text_fn`). No API keys are read or logged.
+
+Prerequisites: Python 3.11+, repo root, tests green.
+
+```bash
+cd /path/to/simula-research
+export PYTHONPATH=src
+export SIMULA_CRITIC_BACKEND=stub
+export SIMULA_HTTP_TIMEOUT_SECONDS=30
+export SIMULA_HTTP_MAX_RETRIES=2
+python3 - <<'PY'
+import tempfile
+from simula_research.critic_provider_adapter import critic_sample_evaluator_from_env, provider_runtime_from_env
+from simula_research.pipeline import run_pipeline
+
+evaluator = critic_sample_evaluator_from_env()
+runtime = provider_runtime_from_env()
+with tempfile.TemporaryDirectory() as tmp:
+    result = run_pipeline(
+        seed=7,
+        model_ids={"generator": "g", "critic_a": "a", "critic_b": "b"},
+        domain_objective="pilot-domain",
+        artifact_root=tmp,
+        taxonomy_config={"max_depth": 1, "branching_factor": 2},
+        provider_runtime=runtime,
+        critic_sample_evaluator=evaluator,
+    )
+    print("run_id", result["manifest"]["run_id"])
+    print("manifest keys", sorted(result["manifest"].keys()))
+PY
+```
+
+Deterministic **replay** table: set `SIMULA_CRITIC_BACKEND=replay` and `SIMULA_CRITIC_REPLAY_JSON` to a JSON file containing a list of `[instantiation_id, critic_id, text, verdict]` rows (see `tests/test_critic_provider_adapter.py`).
+
+Stop if: required env vars are missing for your chosen backend, spend caps would be exceeded, or stage contract validation fails (inspect stderr / rerun with a fixed `artifact_root` under `artifacts/runs/`).
+
 ## Per-run checklist
 
 Before run:

--- a/docs/research-validation-playbook.md
+++ b/docs/research-validation-playbook.md
@@ -75,6 +75,8 @@ Deterministic **replay** table: set `SIMULA_CRITIC_BACKEND=replay` and `SIMULA_C
 
 Stop if: required env vars are missing for your chosen backend, spend caps would be exceeded, or stage contract validation fails (inspect stderr / rerun with a fixed `artifact_root` under `artifacts/runs/`).
 
+For Issue #9 **full** manifest validation on disk, write `manifest.json` with all fields in `validators.validate_manifest_schema` (including `created_at_utc`, `domain_objective`, `owner`, `commit_hash`, `branch`). The minimal `run_pipeline` return manifest is sufficient for stage boot only.
+
 ## Per-run checklist
 
 Before run:

--- a/src/simula_research/critic_provider_adapter.py
+++ b/src/simula_research/critic_provider_adapter.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, TypeVar
+
+from simula_research.provider_protocols import (
+    CriticSampleEvaluatorFn,
+    CriticVerdict,
+    hash_based_critic_verdict,
+    recorded_sample_evaluator,
+    sample_evaluator_from_text_fn,
+)
+
+T = TypeVar("T")
+
+
+def _parse_positive_float(name: str, raw: str) -> float:
+    value = float(raw)
+    if value <= 0:
+        raise ValueError(f"{name} must be positive, got {value!r}")
+    return value
+
+
+def _parse_non_negative_int(name: str, raw: str) -> int:
+    value = int(raw)
+    if value < 0:
+        raise ValueError(f"{name} must be non-negative, got {value!r}")
+    return value
+
+
+def provider_runtime_from_env() -> dict[str, Any]:
+    """Structured provider/runtime metadata for manifests (no secrets; env names only as strings)."""
+    payload: dict[str, Any] = {
+        "source": "environment",
+        "critic_backend": (os.environ.get("SIMULA_CRITIC_BACKEND") or "").strip() or "hash_default",
+    }
+    transport: dict[str, Any] = {}
+    if raw := os.environ.get("SIMULA_HTTP_TIMEOUT_SECONDS"):
+        transport["timeout_s"] = _parse_positive_float("SIMULA_HTTP_TIMEOUT_SECONDS", raw)
+    if raw := os.environ.get("SIMULA_HTTP_MAX_RETRIES"):
+        transport["max_retries"] = _parse_non_negative_int("SIMULA_HTTP_MAX_RETRIES", raw)
+    if raw := os.environ.get("SIMULA_HTTP_BACKOFF_BASE_SECONDS"):
+        transport["backoff_base_s"] = _parse_positive_float("SIMULA_HTTP_BACKOFF_BASE_SECONDS", raw)
+    if transport:
+        payload["http_transport"] = transport
+    for key in ("SIMULA_CRITIC_MODEL_A", "SIMULA_CRITIC_MODEL_B"):
+        if val := os.environ.get(key):
+            payload.setdefault("model_env_aliases", {})[key] = val
+    return payload
+
+
+def retry_with_backoff(
+    operation: Callable[[], T],
+    *,
+    max_retries: int,
+    backoff_base_s: float,
+    rng: random.Random | None = None,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> T:
+    """Bounded retries with linear backoff (stdlib-only; suitable for transport wrappers)."""
+    if max_retries < 0:
+        raise ValueError("max_retries must be >= 0")
+    rng = rng or random.Random()
+    last_exc: BaseException | None = None
+    for attempt in range(max_retries + 1):
+        try:
+            return operation()
+        except Exception as exc:  # noqa: BLE001 — boundary for transport retries
+            last_exc = exc
+            if attempt >= max_retries:
+                break
+            delay = backoff_base_s * (attempt + 1)
+            jitter = rng.uniform(0, backoff_base_s * 0.25)
+            sleep_fn(delay + jitter)
+    assert last_exc is not None
+    raise last_exc
+
+
+def logging_critic_sample_evaluator(
+    inner: CriticSampleEvaluatorFn,
+    failure_log: list[dict[str, Any]],
+) -> CriticSampleEvaluatorFn:
+    """Capture structured failure rows (no raw prompts) for operator review."""
+
+    def _wrapped(sample: dict[str, Any], critic_id: str) -> CriticVerdict:
+        try:
+            return inner(sample, critic_id)
+        except Exception as exc:  # noqa: BLE001
+            failure_log.append(
+                {
+                    "critic_id": critic_id,
+                    "instantiation_id": str(sample.get("instantiation_id", "")),
+                    "error_type": type(exc).__name__,
+                }
+            )
+            raise
+
+    return _wrapped
+
+
+def critic_sample_evaluator_from_env() -> CriticSampleEvaluatorFn | None:
+    """Return None to keep hash-based default; otherwise a non-network evaluator for smoke wiring."""
+    mode = (os.environ.get("SIMULA_CRITIC_BACKEND") or "").strip().lower()
+    if mode in {"", "hash", "default"}:
+        return None
+    if mode == "stub":
+        return sample_evaluator_from_text_fn(hash_based_critic_verdict)
+    if mode == "replay":
+        path = os.environ.get("SIMULA_CRITIC_REPLAY_JSON")
+        if not path:
+            raise ValueError("SIMULA_CRITIC_BACKEND=replay requires SIMULA_CRITIC_REPLAY_JSON")
+        rows = json.loads(Path(path).read_text(encoding="utf-8"))
+        if not isinstance(rows, list):
+            raise ValueError("replay file must be a JSON list of [instantiation_id,critic_id,text,verdict]")
+        table: dict[tuple[str, str, str], CriticVerdict] = {}
+        for row in rows:
+            if not isinstance(row, list) or len(row) != 4:
+                raise ValueError(f"Invalid replay row: {row!r}")
+            inst, critic, text, verdict = row
+            if verdict not in ("accept", "reject"):
+                raise ValueError(f"Invalid verdict in replay row: {verdict!r}")
+            table[(str(inst), str(critic), str(text))] = verdict
+        return recorded_sample_evaluator(table)
+    raise ValueError(f"Unsupported SIMULA_CRITIC_BACKEND={mode!r}")

--- a/src/simula_research/dual_critic.py
+++ b/src/simula_research/dual_critic.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Any
 
-from simula_research.provider_protocols import CriticVerdict, CriticVerdictFn, hash_based_critic_verdict
+from simula_research.provider_protocols import (
+    CriticSampleEvaluatorFn,
+    CriticVerdict,
+    CriticVerdictFn,
+    hash_based_critic_verdict,
+)
 
 
 def _normalized_policy(policy: dict[str, Any] | None) -> dict[str, Any]:
@@ -14,9 +18,13 @@ def _normalized_policy(policy: dict[str, Any] | None) -> dict[str, Any]:
     max_regenerations = int(configured.get("max_regenerations_per_sample", 1))
     if max_regenerations < 0:
         raise ValueError("max_regenerations_per_sample must be >= 0")
+    single_critic_mode = configured.get("single_critic_mode")
+    if single_critic_mode is not None and str(single_critic_mode) not in {"critic_a", "critic_b"}:
+        raise ValueError("single_critic_mode must be one of: critic_a, critic_b")
     return {
         "disagreement_policy": disagreement_policy,
         "max_regenerations_per_sample": max_regenerations,
+        "single_critic_mode": None if single_critic_mode is None else str(single_critic_mode),
     }
 
 
@@ -24,11 +32,31 @@ def adjudicate_samples(
     samples: list[dict[str, Any]],
     policy: dict[str, Any] | None = None,
     critic_verdict: CriticVerdictFn | None = None,
+    critic_sample_evaluator: CriticSampleEvaluatorFn | None = None,
 ) -> dict[str, Any]:
+    if critic_verdict is not None and critic_sample_evaluator is not None:
+        raise ValueError("critic_verdict and critic_sample_evaluator are mutually exclusive")
+
     adjudication_policy = _normalized_policy(policy)
     disagreement_policy = adjudication_policy["disagreement_policy"]
     max_regenerations = adjudication_policy["max_regenerations_per_sample"]
-    decide: Callable[[str, str], CriticVerdict] = critic_verdict or hash_based_critic_verdict
+    single_critic_mode = adjudication_policy["single_critic_mode"]
+
+    text_decide: CriticVerdictFn = critic_verdict or hash_based_critic_verdict
+
+    def _verdict_for_sample(sample_row: dict[str, Any], critic_id: str) -> CriticVerdict:
+        if critic_sample_evaluator is not None:
+            return critic_sample_evaluator(sample_row, critic_id)
+        return text_decide(str(sample_row.get("text", "")), critic_id)
+
+    def _dual_verdicts(sample_row: dict[str, Any]) -> tuple[CriticVerdict, CriticVerdict]:
+        if single_critic_mode == "critic_a":
+            a = _verdict_for_sample(sample_row, "critic_a")
+            return a, a
+        if single_critic_mode == "critic_b":
+            b = _verdict_for_sample(sample_row, "critic_b")
+            return b, b
+        return _verdict_for_sample(sample_row, "critic_a"), _verdict_for_sample(sample_row, "critic_b")
 
     decisions: list[dict[str, Any]] = []
     rejections: list[dict[str, Any]] = []
@@ -41,8 +69,7 @@ def adjudicate_samples(
         meta_prompt_id = str(sample.get("meta_prompt_id", "unknown-meta"))
         source_text = str(sample.get("text", ""))
         regen_count = 0
-        critic_a_decision = decide(source_text, "critic_a")
-        critic_b_decision = decide(source_text, "critic_b")
+        critic_a_decision, critic_b_decision = _dual_verdicts(sample)
 
         if critic_a_decision == critic_b_decision:
             final_status = "accepted" if critic_a_decision == "accept" else "rejected"
@@ -60,8 +87,8 @@ def adjudicate_samples(
             for regeneration_index in range(max_regenerations):
                 regen_count += 1
                 regen_text = f"{regen_text} [regen-{regeneration_index + 1}]"
-                regen_a_decision = decide(regen_text, "critic_a")
-                regen_b_decision = decide(regen_text, "critic_b")
+                regen_row = {**sample, "text": regen_text}
+                regen_a_decision, regen_b_decision = _dual_verdicts(regen_row)
                 regenerations.append(
                     {
                         "instantiation_id": sample_id,

--- a/src/simula_research/issue7_execution_reporting.py
+++ b/src/simula_research/issue7_execution_reporting.py
@@ -69,6 +69,7 @@ def execute_issue7_matrix(
             model_ids=dict(request["model_ids"]),
             domain_objective=str(request["domain_objective"]),
             artifact_root=artifact_root,
+            pipeline_config=dict(request["pipeline_config"]),
         )
 
         stage4 = pipeline_result["stage_outputs"]["stage_4_dual_critic_quality_verification"]
@@ -108,12 +109,6 @@ def execute_issue7_matrix(
         )
 
         quality = compute_quality_metrics(issue5_outputs=stage4)
-        if preset_id == "A1":
-            # A1 models degraded taxonomy shaping by reducing successful complexification evidence.
-            complexity["complexification_precision"] = max(0.0, complexity["complexification_precision"] - 0.35)
-        if preset_id == "A4":
-            # A4 simulates weaker quality filtering under single-critic mode.
-            quality["critic_agreement"] = max(0.0, float(quality["critic_agreement"] or 0.0) - 0.25)
 
         protocol = {
             "domain_objective": request["domain_objective"],

--- a/src/simula_research/local_diversification.py
+++ b/src/simula_research/local_diversification.py
@@ -30,7 +30,17 @@ def build_local_diversification(
     taxonomy: dict[str, Any],
     per_node_instantiation_count: int = 3,
     overlap_rejection_threshold: float = 0.8,
+    *,
+    options: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+    option_values = options or {}
+    per_node_instantiation_count = int(
+        option_values.get("per_node_instantiation_count", per_node_instantiation_count)
+    )
+    overlap_rejection_threshold = float(
+        option_values.get("overlap_rejection_threshold", overlap_rejection_threshold)
+    )
+
     accepted: list[dict[str, Any]] = []
     rejections: list[dict[str, Any]] = []
 

--- a/src/simula_research/pipeline.py
+++ b/src/simula_research/pipeline.py
@@ -10,13 +10,20 @@ from simula_research.complexification import apply_complexification
 from simula_research.dual_critic import adjudicate_samples
 from simula_research.local_diversification import build_local_diversification
 from simula_research.manifest import validate_manifest
-from simula_research.provider_protocols import CriticVerdictFn
+from simula_research.provider_protocols import CriticSampleEvaluatorFn, CriticVerdictFn
 from simula_research.run_artifact_store import FileSystemRunArtifactStore, RunArtifactStore
 from simula_research.stage_contracts import validate_stage_handoffs
 from simula_research.taxonomy import TaxonomyConfig, build_taxonomy
 
 PROTOCOL_VERSION = "0.1.0"
 ARTIFACT_SCHEMA_VERSION = "0.1.0"
+
+DEFAULT_PIPELINE_CONFIG: dict[str, Any] = {
+    "global_diversification_enabled": True,
+    "local_diversification_enabled": True,
+    "complexification_enabled": True,
+    "dual_critic_enabled": True,
+}
 
 STAGE_NAMES = [
     "stage_0_domain_run_spec",
@@ -36,30 +43,45 @@ def run_pipeline(
     taxonomy_config: dict[str, int] | None = None,
     complexification_config: dict[str, Any] | None = None,
     dual_critic_config: dict[str, Any] | None = None,
+    local_diversification_config: dict[str, Any] | None = None,
+    pipeline_config: dict[str, Any] | None = None,
+    provider_runtime: dict[str, Any] | None = None,
     artifact_store_factory: Callable[[Path], RunArtifactStore] | None = None,
     critic_verdict: CriticVerdictFn | None = None,
+    critic_sample_evaluator: CriticSampleEvaluatorFn | None = None,
 ) -> dict[str, object]:
+    if critic_verdict is not None and critic_sample_evaluator is not None:
+        raise ValueError("critic_verdict and critic_sample_evaluator are mutually exclusive")
+
     run_id = f"run-{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}-{uuid4().hex[:8]}"
 
-    manifest = {
+    manifest_pipeline = dict(pipeline_config) if pipeline_config is not None else dict(DEFAULT_PIPELINE_CONFIG)
+
+    manifest: dict[str, Any] = {
         "run_id": run_id,
         "seed": seed,
         "model_ids": model_ids,
         "protocol_version": PROTOCOL_VERSION,
         "artifact_schema_version": ARTIFACT_SCHEMA_VERSION,
+        "pipeline_config": manifest_pipeline,
     }
+    if provider_runtime:
+        manifest["provider_runtime"] = dict(provider_runtime)
     validate_manifest(manifest)
 
     stage_outputs: dict[str, Any] = {
         stage_name: {"status": "placeholder", "run_id": run_id} for stage_name in STAGE_NAMES
     }
 
-    cfg = taxonomy_config or {}
+    taxonomy_cfg = dict(taxonomy_config or {})
+    if pipeline_config is not None and not pipeline_config.get("global_diversification_enabled", True):
+        taxonomy_cfg = {"max_depth": 0, "branching_factor": 1}
+
     taxonomy = build_taxonomy(
         domain_objective=domain_objective,
         config=TaxonomyConfig(
-            max_depth=int(cfg.get("max_depth", 2)),
-            branching_factor=int(cfg.get("branching_factor", 2)),
+            max_depth=int(taxonomy_cfg.get("max_depth", 2)),
+            branching_factor=int(taxonomy_cfg.get("branching_factor", 2)),
         ),
     )
 
@@ -67,9 +89,21 @@ def run_pipeline(
     store_factory = artifact_store_factory or (lambda root: FileSystemRunArtifactStore(root))
     store = store_factory(run_root)
     artifacts = store.persist_taxonomy(taxonomy)
-    local_diversification = build_local_diversification(taxonomy=taxonomy)
+
+    local_options = dict(local_diversification_config or {})
+    if pipeline_config is not None and not pipeline_config.get("local_diversification_enabled", True):
+        local_options["per_node_instantiation_count"] = 1
+
+    local_diversification = build_local_diversification(
+        taxonomy=taxonomy,
+        options=local_options or None,
+    )
     local_artifacts = store.persist_local_diversification(local_diversification)
-    complex_cfg = complexification_config or {}
+
+    complex_cfg = dict(complexification_config or {})
+    if pipeline_config is not None and not pipeline_config.get("complexification_enabled", True):
+        complex_cfg["complexify_fraction"] = 0.0
+
     complexification = apply_complexification(
         samples=local_diversification["instantiations"],
         complexify_fraction=float(complex_cfg.get("complexify_fraction", 0.5)),
@@ -77,10 +111,16 @@ def run_pipeline(
         strategy=str(complex_cfg.get("strategy", "append_reasoning")),
     )
     complex_artifacts = store.persist_complexification(complexification)
+
+    dual_cfg = dict(dual_critic_config or {})
+    if pipeline_config is not None and not pipeline_config.get("dual_critic_enabled", True):
+        dual_cfg["single_critic_mode"] = str(pipeline_config.get("single_critic_mode", "critic_a"))
+
     adjudication = adjudicate_samples(
         samples=complexification["samples"],
-        policy=dual_critic_config,
+        policy=dual_cfg or None,
         critic_verdict=critic_verdict,
+        critic_sample_evaluator=critic_sample_evaluator,
     )
     validate_stage_handoffs(
         taxonomy=taxonomy,
@@ -136,7 +176,7 @@ def run_pipeline(
     )
     reviewed_samples = len(adjudication["decisions"])
     accepted_samples = len(adjudication["accepted_samples"])
-    stage_outputs["stage_4_dual_critic_quality_verification"] = {
+    stage4_payload: dict[str, Any] = {
         "status": "completed",
         "run_id": run_id,
         "reviewed_samples": reviewed_samples,
@@ -147,5 +187,8 @@ def run_pipeline(
         "adjudication_policy": adjudication["policy"],
         "stage4_artifacts": dual_critic_artifacts,
     }
+    if provider_runtime:
+        stage4_payload["provider_runtime"] = dict(provider_runtime)
+    stage_outputs["stage_4_dual_critic_quality_verification"] = stage4_payload
 
     return {"manifest": manifest, "stage_outputs": stage_outputs, "taxonomy": taxonomy}

--- a/src/simula_research/provider_protocols.py
+++ b/src/simula_research/provider_protocols.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import hashlib
-from typing import Literal, Protocol
+from collections.abc import Mapping
+from typing import Any, Literal, Protocol
 
 CriticVerdict = Literal["accept", "reject"]
 
@@ -10,6 +11,35 @@ class CriticVerdictFn(Protocol):
     """Callable used by dual-critic adjudication (Issue #29); swap for tests or real providers."""
 
     def __call__(self, text: str, critic_id: str) -> CriticVerdict: ...
+
+
+class CriticSampleEvaluatorFn(Protocol):
+    """Provider-facing hook (Issue #22): full Stage-3 sample dict (lineage, flags, text) per critic."""
+
+    def __call__(self, sample: dict[str, Any], critic_id: str) -> CriticVerdict: ...
+
+
+def sample_evaluator_from_text_fn(text_fn: CriticVerdictFn) -> CriticSampleEvaluatorFn:
+    """Bridge text-only verdicts to the sample-aware evaluator path (parity / thin wrappers)."""
+
+    def _eval(sample: dict[str, Any], critic_id: str) -> CriticVerdict:
+        return text_fn(str(sample.get("text", "")), critic_id)
+
+    return _eval
+
+
+def recorded_sample_evaluator(
+    table: Mapping[tuple[str, str, str], CriticVerdict],
+) -> CriticSampleEvaluatorFn:
+    """Offline replay from a fixed verdict table keyed by (instantiation_id, critic_id, text)."""
+
+    def _eval(sample: dict[str, Any], critic_id: str) -> CriticVerdict:
+        key = (str(sample.get("instantiation_id", "")), critic_id, str(sample.get("text", "")))
+        if key not in table:
+            raise KeyError(f"recorded_sample_evaluator: missing verdict for {key!r}")
+        return table[key]
+
+    return _eval
 
 
 def hash_based_critic_verdict(text: str, critic_id: str) -> CriticVerdict:

--- a/tests/test_critic_provider_adapter.py
+++ b/tests/test_critic_provider_adapter.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from simula_research.critic_provider_adapter import (
+    critic_sample_evaluator_from_env,
+    logging_critic_sample_evaluator,
+    retry_with_backoff,
+)
+
+
+class CriticProviderAdapterTests(unittest.TestCase):
+    def test_retry_with_backoff_succeeds_after_transient_failure(self) -> None:
+        calls = {"n": 0}
+
+        def op() -> int:
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise RuntimeError("transient")
+            return 7
+
+        result = retry_with_backoff(
+            op,
+            max_retries=3,
+            backoff_base_s=0.01,
+            rng=__import__("random").Random(0),
+            sleep_fn=lambda _s: None,
+        )
+        self.assertEqual(result, 7)
+
+    def test_logging_evaluator_records_failure_metadata(self) -> None:
+        log: list[dict[str, object]] = []
+
+        def boom(_sample: dict[str, object], _cid: str) -> str:
+            raise ValueError("no")
+
+        wrapped = logging_critic_sample_evaluator(boom, log)
+        with self.assertRaises(ValueError):
+            wrapped({"instantiation_id": "i1"}, "critic_a")
+        self.assertEqual(log[0]["instantiation_id"], "i1")
+        self.assertEqual(log[0]["critic_id"], "critic_a")
+        self.assertEqual(log[0]["error_type"], "ValueError")
+
+    def test_critic_sample_evaluator_from_env_stub(self) -> None:
+        env = os.environ
+        old = env.get("SIMULA_CRITIC_BACKEND")
+        try:
+            env["SIMULA_CRITIC_BACKEND"] = "stub"
+            ev = critic_sample_evaluator_from_env()
+            assert ev is not None
+            v = ev({"text": "x", "instantiation_id": "1"}, "critic_a")
+            self.assertIn(v, ("accept", "reject"))
+        finally:
+            if old is None:
+                env.pop("SIMULA_CRITIC_BACKEND", None)
+            else:
+                env["SIMULA_CRITIC_BACKEND"] = old
+
+    def test_critic_sample_evaluator_from_env_replay(self) -> None:
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False, encoding="utf-8") as f:
+            json.dump(
+                [
+                    ["s1", "critic_a", "hello", "accept"],
+                    ["s1", "critic_b", "hello", "accept"],
+                ],
+                f,
+            )
+            path = f.name
+        env = os.environ
+        old_backend = env.get("SIMULA_CRITIC_BACKEND")
+        old_path = env.get("SIMULA_CRITIC_REPLAY_JSON")
+        try:
+            env["SIMULA_CRITIC_BACKEND"] = "replay"
+            env["SIMULA_CRITIC_REPLAY_JSON"] = path
+            ev = critic_sample_evaluator_from_env()
+            assert ev is not None
+            self.assertEqual(ev({"instantiation_id": "s1", "text": "hello"}, "critic_a"), "accept")
+        finally:
+            Path(path).unlink(missing_ok=True)
+            if old_backend is None:
+                env.pop("SIMULA_CRITIC_BACKEND", None)
+            else:
+                env["SIMULA_CRITIC_BACKEND"] = old_backend
+            if old_path is None:
+                env.pop("SIMULA_CRITIC_REPLAY_JSON", None)
+            else:
+                env["SIMULA_CRITIC_REPLAY_JSON"] = old_path
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_issue1_tracer_bullet.py
+++ b/tests/test_issue1_tracer_bullet.py
@@ -21,6 +21,11 @@ class Issue1TracerBulletTest(unittest.TestCase):
             manifest["model_ids"],
             {"generator": "gpt-4.1-mini", "critic_a": "gpt-4.1", "critic_b": "gpt-4.1"},
         )
+        self.assertIn("pipeline_config", manifest)
+        self.assertEqual(
+            manifest["pipeline_config"]["global_diversification_enabled"],
+            True,
+        )
 
         stage_outputs = result["stage_outputs"]
         self.assertEqual(

--- a/tests/test_issue22_dual_critic_evaluators.py
+++ b/tests/test_issue22_dual_critic_evaluators.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+from simula_research.dual_critic import adjudicate_samples
+from simula_research.evaluation_metrics import build_gate_report, compute_quality_metrics
+from simula_research.pipeline import run_pipeline
+from simula_research.provider_protocols import (
+    hash_based_critic_verdict,
+    recorded_sample_evaluator,
+    sample_evaluator_from_text_fn,
+)
+
+
+class Issue22DualCriticEvaluatorsTests(unittest.TestCase):
+    def test_sample_evaluator_wrapped_hash_matches_default_adjudication(self) -> None:
+        samples = [
+            {
+                "instantiation_id": "a",
+                "taxonomy_node_id": "t1",
+                "meta_prompt_id": "m1",
+                "text": "hello",
+                "is_complexified": True,
+            },
+            {
+                "instantiation_id": "b",
+                "taxonomy_node_id": "t2",
+                "meta_prompt_id": "m2",
+                "text": "world",
+                "is_complexified": False,
+            },
+        ]
+        default_adj = adjudicate_samples(samples=samples, policy={"disagreement_policy": "reject"})
+        wrapped_adj = adjudicate_samples(
+            samples=samples,
+            policy={"disagreement_policy": "reject"},
+            critic_sample_evaluator=sample_evaluator_from_text_fn(hash_based_critic_verdict),
+        )
+        self.assertEqual(default_adj["decisions"], wrapped_adj["decisions"])
+        self.assertEqual(default_adj["accepted_samples"], wrapped_adj["accepted_samples"])
+        self.assertEqual(default_adj["rejection_log"], wrapped_adj["rejection_log"])
+
+    def test_recorded_sample_evaluator_is_stable_replay(self) -> None:
+        sample = {
+            "instantiation_id": "inst-x",
+            "taxonomy_node_id": "tax-x",
+            "meta_prompt_id": "mp-x",
+            "text": "fixed-text",
+        }
+        table: dict[tuple[str, str, str], str] = {
+            ("inst-x", "critic_a", "fixed-text"): "accept",
+            ("inst-x", "critic_b", "fixed-text"): "accept",
+        }
+        first = adjudicate_samples(samples=[sample], critic_sample_evaluator=recorded_sample_evaluator(table))
+        second = adjudicate_samples(samples=[sample], critic_sample_evaluator=recorded_sample_evaluator(table))
+        self.assertEqual(first, second)
+        self.assertEqual(first["decisions"][0]["critic_a_decision"], "accept")
+        self.assertEqual(first["decisions"][0]["quality_status"], "accepted")
+
+    def test_sample_evaluator_receives_regenerated_text_in_sample(self) -> None:
+        seen_texts: list[str] = []
+
+        def capture(sample: dict[str, Any], critic_id: str) -> str:
+            seen_texts.append(f"{critic_id}:{sample.get('text', '')}")
+            return "accept" if critic_id == "critic_a" else "reject"
+
+        sample = {
+            "instantiation_id": "r1",
+            "taxonomy_node_id": "t1",
+            "meta_prompt_id": "m1",
+            "text": "base",
+        }
+        adjudicate_samples(
+            samples=[sample],
+            policy={"disagreement_policy": "regenerate", "max_regenerations_per_sample": 1},
+            critic_sample_evaluator=capture,
+        )
+        self.assertTrue(any("[regen-1]" in entry for entry in seen_texts))
+
+    def test_both_evaluator_hooks_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+
+            def _t(_text: str, _cid: str) -> str:
+                return "accept"
+
+            def _s(_sample: dict[str, Any], _cid: str) -> str:
+                return "accept"
+
+            adjudicate_samples(
+                samples=[
+                    {
+                        "instantiation_id": "i",
+                        "taxonomy_node_id": "t",
+                        "meta_prompt_id": "m",
+                        "text": "x",
+                    }
+                ],
+                critic_verdict=_t,
+                critic_sample_evaluator=_s,
+            )
+
+    def test_pipeline_sample_evaluator_issue6_quality_and_gate_report(self) -> None:
+        def accept_complexified_only(sample: dict[str, Any], critic_id: str) -> str:
+            if bool(sample.get("is_complexified")):
+                return "accept"
+            return "reject"
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result = run_pipeline(
+                seed=42,
+                model_ids={"generator": "g", "critic_a": "a", "critic_b": "b"},
+                domain_objective="pilot-domain",
+                artifact_root=tmp_dir,
+                taxonomy_config={"max_depth": 1, "branching_factor": 2},
+                dual_critic_config={"disagreement_policy": "reject"},
+                critic_sample_evaluator=accept_complexified_only,
+            )
+
+            stage4 = result["stage_outputs"]["stage_4_dual_critic_quality_verification"]
+            self.assertEqual(stage4["status"], "completed")
+
+            decisions_path = Path(stage4["stage4_artifacts"]["critic_decisions"])
+            decisions = json.loads(decisions_path.read_text(encoding="utf-8"))
+            for row in decisions:
+                self.assertIn("critic_a_decision", row)
+                self.assertIn("critic_b_decision", row)
+                self.assertIn("quality_status", row)
+
+            quality = compute_quality_metrics(issue5_outputs=stage4)
+            self.assertFalse(quality["requires_issue_5_outputs"])
+            self.assertIsNotNone(quality["acceptance_rate"])
+            self.assertIsNotNone(quality["critic_agreement"])
+
+            gate = build_gate_report(
+                run_identity={"run_id": result["manifest"]["run_id"], "seed": 42},
+                protocol={"critic_adjudication_config": {"mode": "dual_critic"}},
+                coverage_metrics={"node_coverage_ratio": 0.9, "depth_coverage_profile": {"0": 0.9}},
+                complexity_metrics={"complexification_precision": 0.8},
+                quality_metrics=quality,
+            )
+            self.assertIn("gate_decision", gate)
+            self.assertIn("quality", gate)
+
+    def test_run_pipeline_rejects_both_critic_hooks(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self.assertRaises(ValueError):
+                run_pipeline(
+                    seed=1,
+                    model_ids={"generator": "g", "critic_a": "a", "critic_b": "b"},
+                    artifact_root=tmp_dir,
+                    taxonomy_config={"max_depth": 1, "branching_factor": 2},
+                    critic_verdict=hash_based_critic_verdict,
+                    critic_sample_evaluator=sample_evaluator_from_text_fn(hash_based_critic_verdict),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_issue41_provider_runtime.py
+++ b/tests/test_issue41_provider_runtime.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from simula_research.critic_provider_adapter import provider_runtime_from_env
+from simula_research.pipeline import run_pipeline
+
+
+class Issue41ProviderRuntimeTests(unittest.TestCase):
+    def test_manifest_and_stage4_echo_provider_runtime(self) -> None:
+        runtime = {
+            "critic_transport": {"timeout_s": 12.0, "max_retries": 2, "backoff_base_s": 0.5},
+            "models": {"critic_a": "stub-a", "critic_b": "stub-b"},
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_pipeline(
+                seed=3,
+                model_ids={"generator": "g", "critic_a": "a", "critic_b": "b"},
+                artifact_root=tmp,
+                taxonomy_config={"max_depth": 1, "branching_factor": 2},
+                provider_runtime=runtime,
+            )
+        self.assertEqual(result["manifest"]["provider_runtime"], runtime)
+        stage4 = result["stage_outputs"]["stage_4_dual_critic_quality_verification"]
+        self.assertEqual(stage4["provider_runtime"], runtime)
+
+    def test_provider_runtime_from_env_reads_transport_numbers(self) -> None:
+        env = os.environ
+        old = {k: env.get(k) for k in ("SIMULA_HTTP_TIMEOUT_SECONDS", "SIMULA_HTTP_MAX_RETRIES", "SIMULA_CRITIC_BACKEND")}
+        try:
+            env["SIMULA_HTTP_TIMEOUT_SECONDS"] = "30"
+            env["SIMULA_HTTP_MAX_RETRIES"] = "4"
+            env["SIMULA_CRITIC_BACKEND"] = "stub"
+            meta = provider_runtime_from_env()
+            self.assertEqual(meta["http_transport"]["timeout_s"], 30.0)
+            self.assertEqual(meta["http_transport"]["max_retries"], 4)
+            self.assertEqual(meta["critic_backend"], "stub")
+        finally:
+            for key, val in old.items():
+                if val is None:
+                    env.pop(key, None)
+                else:
+                    env[key] = val
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_issue42_pipeline_config_execution.py
+++ b/tests/test_issue42_pipeline_config_execution.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from simula_research.issue7_execution_reporting import execute_issue7_matrix
+from simula_research.pipeline import run_pipeline
+from simula_research.run_config_presets import build_run_request
+
+
+class Issue42PipelineConfigExecutionTests(unittest.TestCase):
+    def test_a1_pipeline_config_reduces_taxonomy_nodes_vs_b0(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            b0 = run_pipeline(
+                seed=7,
+                model_ids={"generator": "g", "critic_a": "a", "critic_b": "b"},
+                domain_objective="pilot-domain",
+                artifact_root=tmp,
+                pipeline_config=build_run_request("B0")["pipeline_config"],
+            )
+            a1 = run_pipeline(
+                seed=7,
+                model_ids={"generator": "g", "critic_a": "a", "critic_b": "b"},
+                domain_objective="pilot-domain",
+                artifact_root=tmp,
+                pipeline_config=build_run_request("A1")["pipeline_config"],
+            )
+        b0_nodes = len(b0["taxonomy"]["nodes"])
+        a1_nodes = len(a1["taxonomy"]["nodes"])
+        self.assertGreater(b0_nodes, a1_nodes)
+        self.assertEqual(a1_nodes, 1)
+
+    def test_a4_single_critic_mirrors_decisions_in_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            a4 = run_pipeline(
+                seed=7,
+                model_ids={"generator": "g", "critic_a": "a", "critic_b": "b"},
+                domain_objective="pilot-domain",
+                artifact_root=tmp,
+                taxonomy_config={"max_depth": 1, "branching_factor": 2},
+                pipeline_config=build_run_request("A4")["pipeline_config"],
+            )
+            stage4 = a4["stage_outputs"]["stage_4_dual_critic_quality_verification"]
+            self.assertEqual(stage4["adjudication_policy"].get("single_critic_mode"), "critic_a")
+            path = Path(stage4["stage4_artifacts"]["critic_decisions"])
+            rows = json.loads(path.read_text(encoding="utf-8"))
+        self.assertGreater(len(rows), 0)
+        for row in rows:
+            self.assertEqual(row["critic_a_decision"], row["critic_b_decision"])
+
+    def test_issue7_matrix_passes_preset_pipeline_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = execute_issue7_matrix(artifact_root=tmp, report_root=tmp)
+        b0_tax = out["run_reports"]["B0"]["coverage"]["eligible_nodes"]
+        a1_tax = out["run_reports"]["A1"]["coverage"]["eligible_nodes"]
+        self.assertGreater(b0_tax, a1_tax)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Integrated vertical slice for real-time LLM validation readiness:

- **#22** — `CriticSampleEvaluatorFn` sample-aware Stage 4 path; `run_pipeline(..., critic_sample_evaluator=...)`; replay helpers; mutual exclusivity with `critic_verdict`.
- **#41** — optional `provider_runtime` on manifest + stage 4 echo; `provider_runtime_from_env()` for non-secret transport metadata.
- **#42** — `pipeline_config` presets from `execute_issue7_matrix` alter taxonomy/local/complexification/dual-critic execution (A1 shallow taxonomy, A4 single critic); reporting-only A1/A4 hacks removed.
- **Adapter** — `critic_provider_adapter.py`: `SIMULA_CRITIC_BACKEND` (`stub`/`replay`), retry/backoff, failure logging.
- **Docs** — `docs/llm-validation-readiness.md`, playbook operator snippet, handoff/README index updates.

Supersedes open PR #43 (issue #22-only branch).

## Test plan

- [x] `PYTHONPATH=src python3 -m unittest discover -s tests -v` (67 tests)
- [x] Provider-shaped smoke: `SIMULA_CRITIC_BACKEND=stub` + `provider_runtime_from_env()`; artifacts under `artifacts/runs/<run_id>/`; incident log `artifacts/reports/llm-smoke/`
- [ ] Human: live vendor HTTP backend (requires API keys + budget approval)

## Smoke evidence

Operator path (no network keys):

```bash
export PYTHONPATH=src
export SIMULA_CRITIC_BACKEND=stub
export SIMULA_HTTP_TIMEOUT_SECONDS=30
export SIMULA_HTTP_MAX_RETRIES=2
```

See `docs/research-validation-playbook.md` § Provider-backed smoke.

## Paper Alignment Check

- **Traceability/Auditability:** Stage artifact paths unchanged (`40_dual_critic_quality/`); `provider_runtime` echoed in manifest/stage 4; env aliases only (no secrets); replay table support for deterministic reruns.
- **Protocol/Comparability:** No threshold/metric formula/ablation definition changes; B0/A1/A4 matrix uses execution-level `pipeline_config` (ADR 0003 preserved).
- **Control-Axis Impact:** Coverage/complexity stages unchanged by critic adapter; A1/A4 toggles affect coverage/complexity/quality axes independently via `pipeline_config`.
- **Deviation Log:** none

Closes #22, closes #41, closes #42


Made with [Cursor](https://cursor.com)