### PR TITLE
Live NVIDIA NIM critic backend (SIMULA_CRITIC_BACKEND=nim)

### DIFF
--- a/src/simula_research/critic_provider_adapter.py
+++ b/src/simula_research/critic_provider_adapter.py
@@ -4,6 +4,8 @@ import json
 import os
 import random
 import time
+import urllib.error
+import urllib.request
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, TypeVar
@@ -17,6 +19,9 @@ from simula_research.provider_protocols import (
 )
 
 T = TypeVar("T")
+
+_NIM_DEFAULT_BASE_URL = "https://integrate.api.nvidia.com/v1/chat/completions"
+_NIM_DEFAULT_MODEL = "llama-4-maverick-17b-128e-instruct"
 
 
 def _parse_positive_float(name: str, raw: str) -> float:
@@ -33,11 +38,19 @@ def _parse_non_negative_int(name: str, raw: str) -> int:
     return value
 
 
+def _parse_positive_int(name: str, raw: str) -> int:
+    value = int(raw)
+    if value <= 0:
+        raise ValueError(f"{name} must be positive, got {value!r}")
+    return value
+
+
 def provider_runtime_from_env() -> dict[str, Any]:
     """Structured provider/runtime metadata for manifests (no secrets; env names only as strings)."""
+    backend = (os.environ.get("SIMULA_CRITIC_BACKEND") or "").strip() or "hash_default"
     payload: dict[str, Any] = {
         "source": "environment",
-        "critic_backend": (os.environ.get("SIMULA_CRITIC_BACKEND") or "").strip() or "hash_default",
+        "critic_backend": backend,
     }
     transport: dict[str, Any] = {}
     if raw := os.environ.get("SIMULA_HTTP_TIMEOUT_SECONDS"):
@@ -51,6 +64,26 @@ def provider_runtime_from_env() -> dict[str, Any]:
     for key in ("SIMULA_CRITIC_MODEL_A", "SIMULA_CRITIC_MODEL_B"):
         if val := os.environ.get(key):
             payload.setdefault("model_env_aliases", {})[key] = val
+    if backend.strip().lower() in {"nim", "nvidia"}:
+        base_url = (
+            (os.environ.get("SIMULA_NIM_BASE_URL") or "").strip()
+            or (os.environ.get("SIMULA_NVIDIA_BASE_URL") or "").strip()
+            or _NIM_DEFAULT_BASE_URL
+        )
+        default_model = (
+            (os.environ.get("SIMULA_NIM_MODEL") or "").strip()
+            or (os.environ.get("SIMULA_NVIDIA_MODEL") or "").strip()
+            or _NIM_DEFAULT_MODEL
+        )
+        payload["nim_critic"] = {
+            "base_url": base_url,
+            "default_model": default_model,
+            "api_key_env": (
+                "NVIDIA_API_KEY"
+                if os.environ.get("NVIDIA_API_KEY")
+                else ("NVAPI_KEY" if os.environ.get("NVAPI_KEY") else None)
+            ),
+        }
     return payload
 
 
@@ -103,6 +136,174 @@ def logging_critic_sample_evaluator(
     return _wrapped
 
 
+def _nvidia_api_key_from_env() -> str:
+    key = (os.environ.get("NVIDIA_API_KEY") or "").strip()
+    if key:
+        return key
+    key = (os.environ.get("NVAPI_KEY") or "").strip()
+    if key:
+        return key
+    raise ValueError("SIMULA_CRITIC_BACKEND=nvidia requires NVIDIA_API_KEY or NVAPI_KEY")
+
+
+def _nvidia_model_for_critic(critic_id: str) -> str:
+    if critic_id == "critic_a":
+        if val := (os.environ.get("SIMULA_CRITIC_MODEL_A") or "").strip():
+            return val
+    if critic_id == "critic_b":
+        if val := (os.environ.get("SIMULA_CRITIC_MODEL_B") or "").strip():
+            return val
+    if val := (os.environ.get("SIMULA_NIM_MODEL") or "").strip():
+        return val
+    if val := (os.environ.get("SIMULA_NVIDIA_MODEL") or "").strip():
+        return val
+    return _NIM_DEFAULT_MODEL
+
+
+def _http_post_json(
+    *,
+    url: str,
+    headers: dict[str, str],
+    payload: dict[str, Any],
+    timeout_s: float,
+) -> dict[str, Any]:
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url=url, data=body, method="POST")
+    for k, v in headers.items():
+        req.add_header(k, v)
+    with urllib.request.urlopen(req, timeout=timeout_s) as resp:  # noqa: S310 - url from env; used for API calls
+        raw = resp.read().decode("utf-8", errors="replace")
+    parsed = json.loads(raw)
+    if not isinstance(parsed, dict):
+        raise ValueError("nvidia_critic_invalid_response")
+    return parsed
+
+
+def _verdict_from_model_text(raw: str) -> CriticVerdict:
+    text = (raw or "").strip().lower()
+    if not text:
+        raise ValueError("nvidia_critic_invalid_response")
+    first = text.split()[0]
+    if first.startswith("accept"):
+        return "accept"
+    if first.startswith("reject"):
+        return "reject"
+    has_accept = "accept" in text
+    has_reject = "reject" in text
+    if has_accept and not has_reject:
+        return "accept"
+    if has_reject and not has_accept:
+        return "reject"
+    raise ValueError("nvidia_critic_invalid_response")
+
+
+def nvidia_critic_sample_evaluator(
+    *,
+    base_url: str | None = None,
+    timeout_s: float | None = None,
+    max_retries: int | None = None,
+    backoff_base_s: float | None = None,
+    max_tokens: int | None = None,
+    http_post_json: Callable[..., dict[str, Any]] = _http_post_json,
+) -> CriticSampleEvaluatorFn:
+    """
+    Live NVIDIA NIM backend (OpenAI-compatible chat completions).
+
+    NOTE: This evaluator intentionally avoids logging prompts/responses and sanitizes raised errors
+    to prevent accidental leakage of sensitive content into operator logs.
+    """
+
+    resolved_base_url = (
+        (base_url or "").strip()
+        or (os.environ.get("SIMULA_NIM_BASE_URL") or "").strip()
+        or (os.environ.get("SIMULA_NVIDIA_BASE_URL") or "").strip()
+        or _NIM_DEFAULT_BASE_URL
+    )
+    resolved_timeout_s: float
+    if timeout_s is not None:
+        resolved_timeout_s = timeout_s
+    elif raw := os.environ.get("SIMULA_HTTP_TIMEOUT_SECONDS"):
+        resolved_timeout_s = _parse_positive_float("SIMULA_HTTP_TIMEOUT_SECONDS", raw)
+    else:
+        resolved_timeout_s = 30.0
+
+    resolved_max_retries: int
+    if max_retries is not None:
+        resolved_max_retries = max_retries
+    elif raw := os.environ.get("SIMULA_HTTP_MAX_RETRIES"):
+        resolved_max_retries = _parse_non_negative_int("SIMULA_HTTP_MAX_RETRIES", raw)
+    else:
+        resolved_max_retries = 2
+
+    resolved_backoff_base_s: float
+    if backoff_base_s is not None:
+        resolved_backoff_base_s = backoff_base_s
+    elif raw := os.environ.get("SIMULA_HTTP_BACKOFF_BASE_SECONDS"):
+        resolved_backoff_base_s = _parse_positive_float("SIMULA_HTTP_BACKOFF_BASE_SECONDS", raw)
+    else:
+        resolved_backoff_base_s = 0.5
+
+    resolved_max_tokens: int
+    if max_tokens is not None:
+        resolved_max_tokens = max_tokens
+    elif raw := os.environ.get("SIMULA_NVIDIA_MAX_TOKENS"):
+        resolved_max_tokens = _parse_positive_int("SIMULA_NVIDIA_MAX_TOKENS", raw)
+    else:
+        resolved_max_tokens = 16
+
+    api_key = _nvidia_api_key_from_env()
+
+    def _eval(sample: dict[str, Any], critic_id: str) -> CriticVerdict:
+        model = _nvidia_model_for_critic(critic_id)
+        text = str(sample.get("text", ""))
+        payload = {
+            "model": model,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": (
+                        "You are a strict binary classifier for a dataset curation pipeline. "
+                        "Given the user's sample text, respond with exactly one token: accept or reject. "
+                        "No punctuation, no explanation."
+                    ),
+                },
+                {"role": "user", "content": text},
+            ],
+            "temperature": 0,
+            "max_tokens": resolved_max_tokens,
+        }
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+        def _op() -> CriticVerdict:
+            try:
+                resp = http_post_json(
+                    url=resolved_base_url,
+                    headers=headers,
+                    payload=payload,
+                    timeout_s=resolved_timeout_s,
+                )
+                choices = resp.get("choices")
+                if not isinstance(choices, list) or not choices:
+                    raise ValueError("nvidia_critic_invalid_response")
+                msg = choices[0].get("message") if isinstance(choices[0], dict) else None
+                content = msg.get("content") if isinstance(msg, dict) else None
+                return _verdict_from_model_text(str(content or ""))
+            except (urllib.error.URLError, TimeoutError, ValueError) as exc:
+                raise RuntimeError(f"nvidia_critic_request_failed:{type(exc).__name__}") from exc
+
+        return retry_with_backoff(
+            _op,
+            max_retries=resolved_max_retries,
+            backoff_base_s=resolved_backoff_base_s,
+        )
+
+    return _eval
+
+
 def critic_sample_evaluator_from_env() -> CriticSampleEvaluatorFn | None:
     """Return None to keep hash-based default; otherwise a non-network evaluator for smoke wiring."""
     mode = (os.environ.get("SIMULA_CRITIC_BACKEND") or "").strip().lower()
@@ -110,6 +311,8 @@ def critic_sample_evaluator_from_env() -> CriticSampleEvaluatorFn | None:
         return None
     if mode == "stub":
         return sample_evaluator_from_text_fn(hash_based_critic_verdict)
+    if mode in {"nim", "nvidia"}:
+        return nvidia_critic_sample_evaluator()
     if mode == "replay":
         path = os.environ.get("SIMULA_CRITIC_REPLAY_JSON")
         if not path:

--- a/tests/test_critic_provider_adapter.py
+++ b/tests/test_critic_provider_adapter.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from simula_research.critic_provider_adapter import (
     critic_sample_evaluator_from_env,
     logging_critic_sample_evaluator,
+    nvidia_critic_sample_evaluator,
     retry_with_backoff,
 )
 
@@ -89,6 +90,107 @@ class CriticProviderAdapterTests(unittest.TestCase):
                 env.pop("SIMULA_CRITIC_REPLAY_JSON", None)
             else:
                 env["SIMULA_CRITIC_REPLAY_JSON"] = old_path
+
+    def test_nvidia_evaluator_happy_path_accept(self) -> None:
+        import simula_research.critic_provider_adapter as adapter
+
+        env = os.environ
+        old = {
+            "SIMULA_CRITIC_BACKEND": env.get("SIMULA_CRITIC_BACKEND"),
+            "NVIDIA_API_KEY": env.get("NVIDIA_API_KEY"),
+            "SIMULA_CRITIC_MODEL_A": env.get("SIMULA_CRITIC_MODEL_A"),
+        }
+        try:
+            env["SIMULA_CRITIC_BACKEND"] = "nim"
+            env["NVIDIA_API_KEY"] = "test-key"
+            env["SIMULA_CRITIC_MODEL_A"] = "critic-a-model"
+
+            def fake_post_json(*, url: str, headers: dict[str, str], payload: dict[str, object], timeout_s: float) -> dict[str, object]:
+                self.assertIn("Authorization", headers)
+                self.assertTrue(headers["Authorization"].startswith("Bearer "))
+                self.assertEqual(payload["model"], "critic-a-model")
+                return {"choices": [{"message": {"content": "accept"}}]}
+
+            ev = nvidia_critic_sample_evaluator(http_post_json=fake_post_json)
+            verdict = ev({"instantiation_id": "i1", "text": "hello world"}, "critic_a")
+            self.assertEqual(verdict, "accept")
+        finally:
+            for k, v in old.items():
+                if v is None:
+                    env.pop(k, None)
+                else:
+                    env[k] = v
+
+    def test_nvidia_evaluator_retries_on_timeout_then_succeeds(self) -> None:
+        import simula_research.critic_provider_adapter as adapter
+
+        env = os.environ
+        old = {
+            "NVIDIA_API_KEY": env.get("NVIDIA_API_KEY"),
+            "SIMULA_HTTP_MAX_RETRIES": env.get("SIMULA_HTTP_MAX_RETRIES"),
+            "SIMULA_HTTP_BACKOFF_BASE_SECONDS": env.get("SIMULA_HTTP_BACKOFF_BASE_SECONDS"),
+        }
+        prev_sleep = adapter.time.sleep
+        try:
+            env["NVIDIA_API_KEY"] = "test-key"
+            env["SIMULA_HTTP_MAX_RETRIES"] = "1"
+            env["SIMULA_HTTP_BACKOFF_BASE_SECONDS"] = "0.001"
+            adapter.time.sleep = lambda _s: None
+            calls = {"n": 0}
+
+            def fake_post_json(*, url: str, headers: dict[str, str], payload: dict[str, object], timeout_s: float) -> dict[str, object]:
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    raise TimeoutError("network timeout with prompt secret")
+                return {"choices": [{"message": {"content": "reject"}}]}
+
+            ev = nvidia_critic_sample_evaluator(http_post_json=fake_post_json)
+            verdict = ev({"instantiation_id": "i1", "text": "prompt secret"}, "critic_b")
+            self.assertEqual(verdict, "reject")
+            self.assertEqual(calls["n"], 2)
+        finally:
+            adapter.time.sleep = prev_sleep
+            for k, v in old.items():
+                if v is None:
+                    env.pop(k, None)
+                else:
+                    env[k] = v
+
+    def test_nvidia_evaluator_missing_api_key_raises(self) -> None:
+        env = os.environ
+        old = {"NVIDIA_API_KEY": env.get("NVIDIA_API_KEY"), "NVAPI_KEY": env.get("NVAPI_KEY")}
+        try:
+            env.pop("NVIDIA_API_KEY", None)
+            env.pop("NVAPI_KEY", None)
+            with self.assertRaises(ValueError):
+                nvidia_critic_sample_evaluator()({"text": "x", "instantiation_id": "i"}, "critic_a")
+        finally:
+            for k, v in old.items():
+                if v is None:
+                    env.pop(k, None)
+                else:
+                    env[k] = v
+
+    def test_nvidia_evaluator_invalid_model_output_is_sanitized(self) -> None:
+        env = os.environ
+        old = {"NVIDIA_API_KEY": env.get("NVIDIA_API_KEY")}
+        try:
+            env["NVIDIA_API_KEY"] = "test-key"
+
+            def fake_post_json(*, url: str, headers: dict[str, str], payload: dict[str, object], timeout_s: float) -> dict[str, object]:
+                return {"choices": [{"message": {"content": "maybe"}}]}
+
+            ev = nvidia_critic_sample_evaluator(http_post_json=fake_post_json, max_retries=0)
+            with self.assertRaises(RuntimeError) as ctx:
+                ev({"instantiation_id": "i1", "text": "super secret sample"}, "critic_a")
+            # Ensure the raised error does not leak the prompt.
+            self.assertNotIn("super secret sample", str(ctx.exception))
+        finally:
+            for k, v in old.items():
+                if v is None:
+                    env.pop(k, None)
+                else:
+                    env[k] = v
 
 
 if __name__ == "__main__":

--- a/tests/test_issue41_provider_runtime.py
+++ b/tests/test_issue41_provider_runtime.py
@@ -45,6 +45,33 @@ class Issue41ProviderRuntimeTests(unittest.TestCase):
                 else:
                     env[key] = val
 
+    def test_provider_runtime_from_env_includes_nvidia_non_secret_fields(self) -> None:
+        env = os.environ
+        old = {
+            "SIMULA_CRITIC_BACKEND": env.get("SIMULA_CRITIC_BACKEND"),
+            "SIMULA_NVIDIA_BASE_URL": env.get("SIMULA_NVIDIA_BASE_URL"),
+            "SIMULA_NVIDIA_MODEL": env.get("SIMULA_NVIDIA_MODEL"),
+            "NVIDIA_API_KEY": env.get("NVIDIA_API_KEY"),
+            "NVAPI_KEY": env.get("NVAPI_KEY"),
+        }
+        try:
+            env["SIMULA_CRITIC_BACKEND"] = "nim"
+            env["SIMULA_NVIDIA_BASE_URL"] = "https://example.com/v1/chat/completions"
+            env["SIMULA_NVIDIA_MODEL"] = "some-model"
+            env["NVIDIA_API_KEY"] = "test-key"
+            env.pop("NVAPI_KEY", None)
+            meta = provider_runtime_from_env()
+            self.assertEqual(meta["critic_backend"], "nim")
+            self.assertEqual(meta["nim_critic"]["base_url"], "https://example.com/v1/chat/completions")
+            self.assertEqual(meta["nim_critic"]["default_model"], "some-model")
+            self.assertEqual(meta["nim_critic"]["api_key_env"], "NVIDIA_API_KEY")
+        finally:
+            for k, v in old.items():
+                if v is None:
+                    env.pop(k, None)
+                else:
+                    env[k] = v
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds a **live NVIDIA NIM** critic backend behind the existing `CriticSampleEvaluatorFn` seam.

- New backend: `SIMULA_CRITIC_BACKEND=nim` (alias: `nvidia`)
- Uses **stdlib** HTTP (`urllib`) against NIM OpenAI-compatible `chat/completions`
- Retries via existing `retry_with_backoff` and transport env knobs
- **Sanitized errors / redaction**: no prompt/response/API key leakage
- `provider_runtime_from_env()` now includes **non-secret** `nim_critic` metadata when backend is active

Refs: #47

## Test plan

- [x] `PYTHONPATH=src python3 -m unittest discover -s tests -v`
- [ ] (Human) Live smoke run with env vars set (API key in env only)

## Operator usage (live)

```bash
export PYTHONPATH=src
export SIMULA_CRITIC_BACKEND=nim
export NVIDIA_API_KEY=...   # do not commit / do not log
export SIMULA_CRITIC_MODEL_A=llama-4-maverick-17b-128e-instruct
export SIMULA_CRITIC_MODEL_B=llama-4-maverick-17b-128e-instruct
export SIMULA_HTTP_TIMEOUT_SECONDS=30
export SIMULA_HTTP_MAX_RETRIES=2
export SIMULA_HTTP_BACKOFF_BASE_SECONDS=0.5
```

## Paper Alignment Check

- **Traceability/Auditability:** preserves run lineage; adds non-secret `provider_runtime` metadata (`nim_critic.base_url/default_model/api_key_env`).
- **Protocol/Comparability:** no changes to thresholds, metric formulas, ablation definitions, or adjudication semantics.
- **Control-Axis Impact:** implements **quality-axis** provider path only; coverage/complexity untouched.
- **Deviation Log:** none.


Made with [Cursor](https://cursor.com)