### PR TITLE
Docs: NIM critic backend runbook

### DIFF
--- a/docs/agents/next-agent-handoff.md
+++ b/docs/agents/next-agent-handoff.md
@@ -100,6 +100,12 @@ Regenerating runs: use `run_pipeline` / Issue #7 tooling; new runs land under `a
    - **#42** `pipeline_config` presets passed from `execute_issue7_matrix` into `run_pipeline` (A1 shallow taxonomy, A4 `single_critic_mode`, etc.); reporting-only A1/A4 metric hacks removed.  
    - **Adapter:** `src/simula_research/critic_provider_adapter.py` — `SIMULA_CRITIC_BACKEND` (`stub` / `replay`), retry helper, failure logging wrapper.
 
+2b. **Live NVIDIA NIM critic backend** — **PR [#48](https://github.com/AtulyaK/simula-research/pull/48)** (merged to `main`)  
+   - Enabled via `SIMULA_CRITIC_BACKEND=nim` (alias: `nvidia`) using stdlib HTTP.
+   - **Default model:** `llama-4-maverick-17b-128e-instruct` (override with `SIMULA_NIM_MODEL` / `SIMULA_NVIDIA_MODEL` or per-critic `SIMULA_CRITIC_MODEL_A/B`).
+   - **Secrets:** `NVIDIA_API_KEY` or `NVAPI_KEY` only; never print to logs.
+   - **Docs:** See `docs/llm-validation-readiness.md` and `docs/research-validation-playbook.md` for operator guardrails, stop conditions, and deterministic `stub`/`replay` vs live `nim` reproducibility expectations.
+
 3. **Generator / earlier-stage protocols**  
    - **#29** only injected **critic verdict**. Taxonomy, local diversification, and complexification are still deterministic in-repo logic.  
    - **Goal:** `Protocol` + factory hooks mirroring `critic_verdict` / `artifact_store_factory`, with **bit-identical** default factories.  

--- a/docs/llm-validation-readiness.md
+++ b/docs/llm-validation-readiness.md
@@ -62,6 +62,43 @@ The codebase supports a deterministic full pipeline and milestone evidence. LLM-
   - backoff policy
   - max retry budget per run
 
+### Live Stage-4 critic backend: NVIDIA NIM (OpenAI-compatible)
+
+This repo supports a **live** Stage-4 critic backend via NVIDIA NIM behind `SIMULA_CRITIC_BACKEND=nim` (alias: `nvidia`).
+
+**Default model** (if you do not override it): **`llama-4-maverick-17b-128e-instruct`**.
+
+**Required secrets (do not log):**
+
+- `NVIDIA_API_KEY` (preferred) or `NVAPI_KEY`
+
+**Non-secret transport/model knobs (safe to record in `provider_runtime`):**
+
+- `SIMULA_CRITIC_BACKEND=nim` (or `nvidia`)
+- `SIMULA_NIM_BASE_URL` (or `SIMULA_NVIDIA_BASE_URL`)  
+  Defaults to `https://integrate.api.nvidia.com/v1/chat/completions`
+- `SIMULA_NIM_MODEL` (or `SIMULA_NVIDIA_MODEL`)  
+  Defaults to `llama-4-maverick-17b-128e-instruct`
+- `SIMULA_CRITIC_MODEL_A`, `SIMULA_CRITIC_MODEL_B`  
+  Optional per-critic overrides (recommended for explicitness)
+- `SIMULA_NVIDIA_MAX_TOKENS`  
+  Max tokens for the critic response (defaults to 16; the critic is instructed to return exactly one token: `accept` or `reject`)
+- `SIMULA_HTTP_TIMEOUT_SECONDS` (defaults to 30)
+- `SIMULA_HTTP_MAX_RETRIES` (defaults to 2)
+- `SIMULA_HTTP_BACKOFF_BASE_SECONDS` (defaults to 0.5)
+
+**Safety invariants (by design):**
+
+- The live NIM evaluator **does not print prompts/responses**.
+- Errors raised by the transport wrapper are **sanitized** (no raw provider payloads).
+- Operator-facing structured logs should only contain **IDs + error types**, never sample text.
+
+**Stop conditions (operator guardrails):**
+
+- If you cannot confirm budget caps for the run, **do not start** live validation.
+- If you observe repeated `nvidia_critic_request_failed:*` errors beyond your retry budget, **stop the batch** and capture an incident note (without raw text).
+- If acceptance/rejection becomes unstable and dominates quality metrics, **stop** and run a focused diagnosis before continuing (do not “average it out”).
+
 ## 3) Data and compliance controls
 
 - Define whether prompts/responses may contain sensitive or regulated content.
@@ -77,6 +114,19 @@ The codebase supports a deterministic full pipeline and milestone evidence. LLM-
 - Persist complete run identity (`run_id`, seed, model IDs, protocol version, artifact schema version, commit hash, branch).
 - Persist artifacts under `artifacts/runs/<run_id>/...` following `docs/reproducibility-ops.md`.
 - Ensure stage-4 path alignment with current convention: `40_dual_critic_quality/`.
+
+### Deterministic `stub`/`replay` vs live `nim` (reproducibility expectations)
+
+Stage-4 critic non-determinism is handled explicitly via **backend selection**:
+
+- **`SIMULA_CRITIC_BACKEND=stub`**: deterministic, non-network “provider-shaped” path. Uses a hash-based verdict on text and is suitable for CI and baseline reproducibility checks.
+- **`SIMULA_CRITIC_BACKEND=replay`**: deterministic, non-network path that looks up verdicts from a fixed table (`SIMULA_CRITIC_REPLAY_JSON`). Use this when you need to **re-run exactly** against a previously captured critic decision table without re-contacting a provider.
+- **`SIMULA_CRITIC_BACKEND=nim`**: live provider-backed path. Even with `temperature=0`, you should treat it as **potentially drift-prone**. For “auditability”, always record:
+  - commit hash + branch,
+  - backend + base URL,
+  - explicit critic model IDs per critic (`SIMULA_CRITIC_MODEL_A` / `SIMULA_CRITIC_MODEL_B`),
+  - transport knobs (timeouts/retries),
+  - and any incident log about failures/retries (without raw text).
 
 ## 5) Baseline repo health gate
 

--- a/docs/research-validation-playbook.md
+++ b/docs/research-validation-playbook.md
@@ -77,6 +77,67 @@ Stop if: required env vars are missing for your chosen backend, spend caps would
 
 For Issue #9 **full** manifest validation on disk, write `manifest.json` with all fields in `validators.validate_manifest_schema` (including `created_at_utc`, `domain_objective`, `owner`, `commit_hash`, `branch`). The minimal `run_pipeline` return manifest is sufficient for stage boot only.
 
+## Live provider smoke: NVIDIA NIM Stage-4 critics (only if keys already configured)
+
+This is the smallest live test of the merged NIM critic backend (**PR #48**). It uses stdlib HTTP and is designed to avoid logging raw sample text or provider payloads.
+
+**Critical constraints:**
+
+- Only run this if `NVIDIA_API_KEY` or `NVAPI_KEY` is already present in the environment.
+- Use explicit model IDs for auditability; default model is **`llama-4-maverick-17b-128e-instruct`**.
+- Treat live-provider runs as potentially drift-prone even at `temperature=0`.
+
+Suggested minimal smoke (tiny taxonomy; short run):
+
+```bash
+cd /path/to/simula-research
+export PYTHONPATH=src
+export SIMULA_CRITIC_BACKEND=nim
+
+# Optional but recommended (explicitness)
+export SIMULA_CRITIC_MODEL_A=llama-4-maverick-17b-128e-instruct
+export SIMULA_CRITIC_MODEL_B=llama-4-maverick-17b-128e-instruct
+
+# Transport guardrails (bounded retries + timeouts)
+export SIMULA_HTTP_TIMEOUT_SECONDS=30
+export SIMULA_HTTP_MAX_RETRIES=1
+export SIMULA_HTTP_BACKOFF_BASE_SECONDS=0.5
+
+python3 - <<'PY'
+import os
+import tempfile
+
+from simula_research.critic_provider_adapter import critic_sample_evaluator_from_env, provider_runtime_from_env
+from simula_research.pipeline import run_pipeline
+
+if not (os.environ.get("NVIDIA_API_KEY") or os.environ.get("NVAPI_KEY")):
+    raise SystemExit("Missing NVIDIA_API_KEY/NVAPI_KEY; skip live smoke.")
+
+evaluator = critic_sample_evaluator_from_env()
+runtime = provider_runtime_from_env()
+with tempfile.TemporaryDirectory() as tmp:
+    result = run_pipeline(
+        seed=7,
+        model_ids={"generator": "g", "critic_a": "a", "critic_b": "b"},
+        domain_objective="nim-smoke",
+        artifact_root=tmp,
+        taxonomy_config={"max_depth": 1, "branching_factor": 2},
+        provider_runtime=runtime,
+        critic_sample_evaluator=evaluator,
+    )
+    print("run_id", result["manifest"]["run_id"])
+    # Intentionally do NOT print sample texts or provider responses.
+    print("critic_backend", runtime.get("critic_backend"))
+    print("nim_default_model", runtime.get("nim_critic", {}).get("default_model"))
+PY
+```
+
+**Stop immediately** if:
+
+- you cannot confirm budget caps for the run,
+- repeated transport failures occur (`nvidia_critic_request_failed:*`),
+- or Stage contract validation fails.
+
 ## Per-run checklist
 
 Before run:


### PR DESCRIPTION
## Summary
- Documented live NVIDIA NIM Stage-4 critic backend (`SIMULA_CRITIC_BACKEND=nim` / `nvidia`) env vars and defaults.
- Added safety guidance: redaction expectations, sanitized errors, budget guardrails, and explicit stop conditions.
- Clarified deterministic `stub`/`replay` vs live `nim` reproducibility expectations and added a minimal live smoke snippet (only runs if keys already present).

## Test plan
- [x] `PYTHONPATH=src python3 -m unittest discover -s tests -v`
- [ ] Optional: run the documented NIM smoke snippet **only** if `NVIDIA_API_KEY`/`NVAPI_KEY` already exist in your environment.

## Paper Alignment Check
- **Traceability/Auditability:** Documents how to capture backend/model/transport metadata via `provider_runtime_from_env()` while avoiding secret leakage; encourages explicit model IDs and incident logs without raw text.
- **Protocol/Comparability:** No changes to thresholds, metric formulas, or ablation semantics; guidance preserves baseline/ablation comparability by separating deterministic replay from live drift-prone runs.
- **Control-axis impact:** Clarifies Stage-4 critic integration only; does not conflate coverage/complexity axes with quality verification.
- **Deviations:** none.

Made with [Cursor](https://cursor.com)