### PR TITLE
Fix accepted artifact after regeneration (Issue #51)

### DIFF
--- a/src/simula_research/dual_critic.py
+++ b/src/simula_research/dual_critic.py
@@ -70,6 +70,9 @@ def adjudicate_samples(
         source_text = str(sample.get("text", ""))
         regen_count = 0
         critic_a_decision, critic_b_decision = _dual_verdicts(sample)
+        final_text = source_text
+        final_critic_a_decision = critic_a_decision
+        final_critic_b_decision = critic_b_decision
 
         if critic_a_decision == critic_b_decision:
             final_status = "accepted" if critic_a_decision == "accept" else "rejected"
@@ -103,6 +106,9 @@ def adjudicate_samples(
                 if regen_a_decision == "accept" and regen_b_decision == "accept":
                     final_status = "accepted"
                     final_reason = "regeneration_consensus_accept"
+                    final_text = regen_text
+                    final_critic_a_decision = regen_a_decision
+                    final_critic_b_decision = regen_b_decision
                     break
 
         decisions.append(
@@ -125,8 +131,9 @@ def adjudicate_samples(
             accepted_samples.append(
                 {
                     **sample,
-                    "critic_a_decision": critic_a_decision,
-                    "critic_b_decision": critic_b_decision,
+                    "text": final_text,
+                    "critic_a_decision": final_critic_a_decision,
+                    "critic_b_decision": final_critic_b_decision,
                     "quality_status": "accepted",
                     "regeneration_count": regen_count,
                 }

--- a/tests/test_issue22_dual_critic_evaluators.py
+++ b/tests/test_issue22_dual_critic_evaluators.py
@@ -81,6 +81,30 @@ class Issue22DualCriticEvaluatorsTests(unittest.TestCase):
         )
         self.assertTrue(any("[regen-1]" in entry for entry in seen_texts))
 
+    def test_regenerated_acceptance_preserves_regenerated_text_and_final_decisions(self) -> None:
+        def evaluator(sample: dict[str, Any], critic_id: str) -> str:
+            text = str(sample.get("text", ""))
+            if "[regen-1]" in text:
+                return "accept"
+            return "accept" if critic_id == "critic_a" else "reject"
+
+        sample = {
+            "instantiation_id": "r2",
+            "taxonomy_node_id": "t1",
+            "meta_prompt_id": "m1",
+            "text": "base",
+        }
+        adjudication = adjudicate_samples(
+            samples=[sample],
+            policy={"disagreement_policy": "regenerate", "max_regenerations_per_sample": 1},
+            critic_sample_evaluator=evaluator,
+        )
+        self.assertEqual(len(adjudication["accepted_samples"]), 1)
+        accepted = adjudication["accepted_samples"][0]
+        self.assertIn("[regen-1]", accepted["text"])
+        self.assertEqual(accepted["critic_a_decision"], "accept")
+        self.assertEqual(accepted["critic_b_decision"], "accept")
+
     def test_both_evaluator_hooks_rejected(self) -> None:
         with self.assertRaises(ValueError):
 


### PR DESCRIPTION
## Summary
- When dual-critic disagreement triggers regeneration and the regenerated variant is accepted, persist the regenerated text and final critic decisions in `accepted_samples`.
- Adds a unit test guarding against regressing to the pre-regeneration text.

## Test plan
- `PYTHONPATH=src python -m unittest discover -s tests`

Fixes #51

Made with [Cursor](https://cursor.com)