### PR TITLE
Clarify manifest validation modes (boot vs full) (#61)

### DIFF
--- a/docs/reproducibility-ops.md
+++ b/docs/reproducibility-ops.md
@@ -12,9 +12,43 @@ Each run must be:
 - **replayable**: same config + seed + model versions can rerun deterministically where possible.
 - **auditable**: enough metadata exists to explain any deviation.
 
+## Manifest validation modes (boot vs full)
+
+Two validators apply at different lifecycle points. Do not confuse them when debugging missing-field errors.
+
+| Mode | Entry point | When it runs | On failure |
+|------|-------------|--------------|------------|
+| **boot** | `manifest.validate_manifest` or `validators.validate_manifest_by_mode(mode="boot")` | Start of `run_pipeline`, before stages execute | `ValueError` (boot wrapper returns `ok: false`) |
+| **full** | `validators.validate_manifest_schema` or `validate_manifest_by_mode(mode="full")` | Issue #9 reproducibility checks, pre-publication ops, CLI-style disk validation | Structured `{"ok": false, "issues": [...]}` |
+
+### Boot-required fields (`manifest.validate_manifest`)
+
+Used by the default pipeline only. Required keys:
+
+- `run_id`, `created_at_utc`, `seed`, `domain_objective`, `model_ids`
+- `protocol_version`, `artifact_schema_version`
+
+`run_pipeline` also attaches `pipeline_config` (and optional `provider_runtime`) on the in-memory manifest, but **boot validation does not require or type-check those keys**. They are required only under **full** validation below.
+
+### Full reproducibility fields (`validators.validate_manifest_schema`)
+
+Required for persisted `manifest.json` under `artifacts/runs/<run_id>/` when running Issue #9 checks or the operational checklist in this guide. Includes all boot fields **plus**:
+
+- `owner`, `branch`, `commit_hash`
+- `pipeline_config` (non-empty object)
+- `baseline_or_ablation_tag`
+
+`model_ids` values must be non-empty strings in full mode (boot only requires a non-empty object).
+
+### Operator guidance
+
+1. **Local pipeline / smoke runs** — `run_pipeline` boot validation is sufficient; returned manifest may fail full schema until you add Issue #9 metadata before archival.
+2. **Matrix / milestone evidence** — use manifests produced by `execute_issue7_matrix` or extend smoke manifests per the JSON example below; run `validate_manifest_schema` on disk.
+3. **Single entry point** — `validate_manifest_by_mode(manifest, mode="boot"|"full")` selects the mode explicitly without changing default pipeline behavior.
+
 ## Required run metadata
 
-Every run manifest must include:
+Every run manifest must include (full reproducibility mode):
 
 - `run_id`
 - `created_at_utc`
@@ -100,7 +134,7 @@ Issue #9 comparability hard gates treat prose in `details` as human-readable onl
 
 ## Operational checks before any report publication
 
-- Manifest complete and schema-valid.
+- Manifest complete and **full**-mode schema-valid (`validate_manifest_schema` or `validate_manifest_by_mode(mode="full")`).
 - Artifact tree complete for all required stages.
 - Metrics generated from persisted artifacts, not transient logs.
 - Gate decision references metric files by path.

--- a/src/simula_research/__init__.py
+++ b/src/simula_research/__init__.py
@@ -1,5 +1,9 @@
 from simula_research.pipeline import run_pipeline
-from simula_research.validators import validate_artifact_tree, validate_manifest_schema
+from simula_research.validators import (
+    validate_artifact_tree,
+    validate_manifest_by_mode,
+    validate_manifest_schema,
+)
 from simula_research.evaluation_metrics import (
     build_gate_report,
     compute_complexity_metrics,
@@ -10,6 +14,7 @@ from simula_research.evaluation_metrics import (
 __all__ = [
     "run_pipeline",
     "validate_manifest_schema",
+    "validate_manifest_by_mode",
     "validate_artifact_tree",
     "compute_coverage_metrics",
     "compute_complexity_metrics",

--- a/src/simula_research/manifest.py
+++ b/src/simula_research/manifest.py
@@ -1,18 +1,31 @@
+"""Pipeline boot manifest validation (fast path).
+
+``validate_manifest`` enforces the **boot** field set required before stage
+execution in ``run_pipeline``. It raises ``ValueError`` on failure.
+
+For Issue #9 **full** reproducibility checks (owner, branch, commit_hash,
+``pipeline_config``, ``baseline_or_ablation_tag``, …), use
+``validators.validate_manifest_schema`` or ``validators.validate_manifest_by_mode(mode="full")``.
+See ``docs/reproducibility-ops.md`` (Manifest validation modes).
+"""
+
 from __future__ import annotations
 
 from typing import Any
 
+BOOT_REQUIRED_MANIFEST_FIELDS: tuple[str, ...] = (
+    "run_id",
+    "created_at_utc",
+    "seed",
+    "domain_objective",
+    "model_ids",
+    "protocol_version",
+    "artifact_schema_version",
+)
+
 MANIFEST_SCHEMA: dict[str, Any] = {
     "type": "object",
-    "required": [
-        "run_id",
-        "created_at_utc",
-        "seed",
-        "domain_objective",
-        "model_ids",
-        "protocol_version",
-        "artifact_schema_version",
-    ],
+    "required": list(BOOT_REQUIRED_MANIFEST_FIELDS),
     "properties": {
         "run_id": {"type": "string", "minLength": 1},
         "created_at_utc": {"type": "string", "minLength": 1},
@@ -26,7 +39,13 @@ MANIFEST_SCHEMA: dict[str, Any] = {
 
 
 def validate_manifest(manifest: dict[str, Any]) -> None:
-    for field in MANIFEST_SCHEMA["required"]:
+    """Validate manifest for pipeline boot (raises ``ValueError``).
+
+    Does **not** require reproducibility-ops fields such as ``owner``,
+    ``commit_hash``, or ``baseline_or_ablation_tag``. Optional keys present on
+    the in-memory manifest (e.g. ``pipeline_config``) are not validated here.
+    """
+    for field in BOOT_REQUIRED_MANIFEST_FIELDS:
         if field not in manifest:
             raise ValueError(f"Missing required manifest field: {field}")
 

--- a/src/simula_research/validators.py
+++ b/src/simula_research/validators.py
@@ -1,7 +1,21 @@
+"""Reproducibility validators for on-disk runs (Issue #9).
+
+``validate_manifest_schema`` applies the **full** manifest field set from
+``docs/reproducibility-ops.md``. ``manifest.validate_manifest`` is the narrower
+**boot** check used by ``run_pipeline`` before stages run.
+
+Use ``validate_manifest_by_mode`` when operators need a single entry point with
+explicit ``mode="boot"`` or ``mode="full"``.
+"""
+
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
+
+from simula_research.manifest import validate_manifest
+
+ManifestValidationMode = Literal["boot", "full"]
 
 # Reproducibility-ops required manifest fields.
 REQUIRED_MANIFEST_FIELDS: tuple[str, ...] = (
@@ -42,6 +56,11 @@ def _validation_result(kind: str, issues: list[str], assumptions: list[str]) -> 
 
 
 def validate_manifest_schema(manifest: dict[str, Any]) -> dict[str, Any]:
+    """Validate manifest against the full reproducibility-ops field set.
+
+    Returns a structured result dict (does not raise). Boot-only manifests from
+    ``run_pipeline`` are expected to fail until Issue #9 fields are added on disk.
+    """
     issues: list[str] = []
     assumptions = [
         "Manifest payload is already parsed as JSON object",
@@ -74,6 +93,48 @@ def validate_manifest_schema(manifest: dict[str, Any]) -> dict[str, Any]:
         issues.append("field pipeline_config must be an object")
 
     return _validation_result(kind="manifest", issues=issues, assumptions=assumptions)
+
+
+def validate_manifest_by_mode(
+    manifest: dict[str, Any],
+    *,
+    mode: ManifestValidationMode = "boot",
+) -> dict[str, Any]:
+    """Validate manifest in boot or full reproducibility mode.
+
+    - ``boot``: delegates to ``manifest.validate_manifest`` (pipeline default).
+    - ``full``: delegates to ``validate_manifest_schema`` (Issue #9 / ops).
+    """
+    if mode == "full":
+        result = validate_manifest_schema(manifest)
+        result["validation_mode"] = "full"
+        return result
+
+    try:
+        validate_manifest(manifest)
+    except ValueError as exc:
+        return {
+            **_validation_result(
+                kind="manifest",
+                issues=[str(exc)],
+                assumptions=[
+                    "Boot mode uses manifest.validate_manifest (raises converted to issues)",
+                ],
+            ),
+            "validation_mode": "boot",
+        }
+
+    return {
+        **_validation_result(
+            kind="manifest",
+            issues=[],
+            assumptions=[
+                "Boot mode uses manifest.validate_manifest",
+                "Does not require owner, branch, commit_hash, or baseline_or_ablation_tag",
+            ],
+        ),
+        "validation_mode": "boot",
+    }
 
 
 def validate_artifact_tree(run_root: str | Path) -> dict[str, Any]:

--- a/tests/test_issue61_manifest_validation_modes.py
+++ b/tests/test_issue61_manifest_validation_modes.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import unittest
+
+from simula_research.manifest import BOOT_REQUIRED_MANIFEST_FIELDS, validate_manifest
+from simula_research.pipeline import PROTOCOL_VERSION, ARTIFACT_SCHEMA_VERSION, run_pipeline
+from simula_research.validators import (
+    REQUIRED_MANIFEST_FIELDS,
+    validate_manifest_by_mode,
+    validate_manifest_schema,
+)
+
+
+class Issue61ManifestValidationModesTests(unittest.TestCase):
+    def _pipeline_boot_manifest(self) -> dict[str, object]:
+        """Shape produced by run_pipeline before persistence (boot-only fields)."""
+        return {
+            "run_id": "run-20260526T010000Z-abc12345",
+            "created_at_utc": "2026-05-26T01:00:00Z",
+            "seed": 7,
+            "domain_objective": "pilot-domain",
+            "model_ids": {"generator": "stub", "critic_a": "stub", "critic_b": "stub"},
+            "protocol_version": PROTOCOL_VERSION,
+            "artifact_schema_version": ARTIFACT_SCHEMA_VERSION,
+            "pipeline_config": {"dual_critic_enabled": True},
+        }
+
+    def _full_reproducibility_manifest(self) -> dict[str, object]:
+        boot = self._pipeline_boot_manifest()
+        return {
+            **boot,
+            "owner": "agent",
+            "branch": "main",
+            "commit_hash": "abc123def456",
+            "baseline_or_ablation_tag": "B0",
+        }
+
+    def test_boot_required_fields_are_subset_of_full_schema(self) -> None:
+        boot_set = set(BOOT_REQUIRED_MANIFEST_FIELDS)
+        full_set = set(REQUIRED_MANIFEST_FIELDS)
+        self.assertTrue(boot_set.issubset(full_set))
+        self.assertEqual(
+            full_set - boot_set,
+            {
+                "owner",
+                "branch",
+                "commit_hash",
+                "pipeline_config",
+                "baseline_or_ablation_tag",
+            },
+        )
+
+    def test_pipeline_boot_manifest_passes_boot_validator(self) -> None:
+        validate_manifest(self._pipeline_boot_manifest())  # raises on failure
+
+    def test_pipeline_boot_manifest_fails_full_schema(self) -> None:
+        result = validate_manifest_schema(self._pipeline_boot_manifest())
+        self.assertFalse(result["ok"])
+        self.assertTrue(
+            any("missing required field: owner" in issue for issue in result["issues"])
+        )
+
+    def test_full_manifest_passes_boot_and_full_validators(self) -> None:
+        manifest = self._full_reproducibility_manifest()
+        validate_manifest(manifest)
+        result = validate_manifest_schema(manifest)
+        self.assertTrue(result["ok"])
+
+    def test_validate_manifest_by_mode_boot_matches_raise_semantics(self) -> None:
+        boot_result = validate_manifest_by_mode(self._pipeline_boot_manifest(), mode="boot")
+        self.assertTrue(boot_result["ok"])
+        self.assertEqual(boot_result["validation_mode"], "boot")
+
+        missing = self._pipeline_boot_manifest()
+        missing.pop("run_id")
+        boot_fail = validate_manifest_by_mode(missing, mode="boot")
+        self.assertFalse(boot_fail["ok"])
+        self.assertIn("run_id", boot_fail["issues"][0])
+
+    def test_validate_manifest_by_mode_full_delegates_to_schema_validator(self) -> None:
+        full_ok = validate_manifest_by_mode(self._full_reproducibility_manifest(), mode="full")
+        self.assertTrue(full_ok["ok"])
+        self.assertEqual(full_ok["validation_mode"], "full")
+
+        boot_only = validate_manifest_by_mode(self._pipeline_boot_manifest(), mode="full")
+        self.assertFalse(boot_only["ok"])
+
+    def test_run_pipeline_still_uses_boot_validation_only(self) -> None:
+        result = run_pipeline(
+            seed=1,
+            model_ids={"generator": "g", "critic_a": "a", "critic_b": "b"},
+            artifact_root="artifacts/runs",
+        )
+        manifest = result["manifest"]
+        validate_manifest(manifest)
+        full_check = validate_manifest_schema(manifest)
+        self.assertFalse(full_check["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Documents **boot** (`manifest.validate_manifest` / `run_pipeline`) vs **full** (`validators.validate_manifest_schema` / Issue #9) manifest validation in `docs/reproducibility-ops.md` with field tables and operator guidance.
- Adds `BOOT_REQUIRED_MANIFEST_FIELDS`, module docstrings, and `validate_manifest_by_mode(mode="boot"|"full")` as an explicit unified entry point without changing default pipeline behavior.
- Adds `tests/test_issue61_manifest_validation_modes.py` (TDD) asserting boot ⊂ full field sets, pipeline boot pass/fail semantics, and unchanged `run_pipeline` boot path.

Closes #61

## Test plan

- [x] `PYTHONPATH=src python -m unittest tests.test_issue61_manifest_validation_modes tests.test_issue9_reproducibility tests.test_validators`

## Paper Alignment Check

- **Traceability/Auditability:** Validation modes are named and documented; `validation_mode` is returned on the unified wrapper so ops logs can record which check ran. No change to artifact paths or run_id lineage.
- **Protocol/Comparability:** No ADR 0003 threshold, metric formula, gate, or ablation changes. `validate_manifest_schema` semantics unchanged; `run_pipeline` still calls boot-only `validate_manifest`.
- **Control-Axis Impact:** None on coverage/complexity/quality stage logic—metadata validation only.
- **Deviation Log:** none


Made with [Cursor](https://cursor.com)