### PR TITLE
Protocol hooks for Stages 1–3 (bit-identical defaults)

### DIFF
--- a/docs/pipeline-spec.md
+++ b/docs/pipeline-spec.md
@@ -172,6 +172,8 @@ Filesystem persistence for Stages 1–4 uses `src/simula_research/run_artifact_s
 
 Dual-critic adjudication accepts an optional `critic_verdict` callable (`CriticVerdictFn` in `src/simula_research/provider_protocols.py`); the default remains the deterministic hash-based stub used for research-phase replay.
 
+Stages 1–3 accept optional provider callables (`TaxonomyProviderFn`, `LocalDiversificationProviderFn`, `ComplexificationProviderFn`) on `run_pipeline`; defaults (`default_taxonomy_provider`, `default_local_diversification_provider`, `default_complexification_provider`) delegate to the in-repo deterministic implementations with no behavior change when hooks are omitted (Issue #60).
+
 ## Configuration knobs by control axis
 
 ### Coverage

--- a/src/simula_research/pipeline.py
+++ b/src/simula_research/pipeline.py
@@ -6,14 +6,21 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
-from simula_research.complexification import apply_complexification
 from simula_research.dual_critic import adjudicate_samples
-from simula_research.local_diversification import build_local_diversification
 from simula_research.manifest import validate_manifest
-from simula_research.provider_protocols import CriticSampleEvaluatorFn, CriticVerdictFn
+from simula_research.provider_protocols import (
+    ComplexificationProviderFn,
+    CriticSampleEvaluatorFn,
+    CriticVerdictFn,
+    LocalDiversificationProviderFn,
+    TaxonomyProviderFn,
+    default_complexification_provider,
+    default_local_diversification_provider,
+    default_taxonomy_provider,
+)
 from simula_research.run_artifact_store import FileSystemRunArtifactStore, RunArtifactStore
 from simula_research.stage_contracts import validate_stage_handoffs
-from simula_research.taxonomy import TaxonomyConfig, build_taxonomy
+from simula_research.taxonomy import TaxonomyConfig
 
 PROTOCOL_VERSION = "0.1.0"
 ARTIFACT_SCHEMA_VERSION = "0.1.0"
@@ -47,6 +54,9 @@ def run_pipeline(
     pipeline_config: dict[str, Any] | None = None,
     provider_runtime: dict[str, Any] | None = None,
     artifact_store_factory: Callable[[Path], RunArtifactStore] | None = None,
+    taxonomy_provider: TaxonomyProviderFn | None = None,
+    local_diversification_provider: LocalDiversificationProviderFn | None = None,
+    complexification_provider: ComplexificationProviderFn | None = None,
     critic_verdict: CriticVerdictFn | None = None,
     critic_sample_evaluator: CriticSampleEvaluatorFn | None = None,
 ) -> dict[str, object]:
@@ -80,9 +90,10 @@ def run_pipeline(
     if pipeline_config is not None and not pipeline_config.get("global_diversification_enabled", True):
         taxonomy_cfg = {"max_depth": 0, "branching_factor": 1}
 
-    taxonomy = build_taxonomy(
-        domain_objective=domain_objective,
-        config=TaxonomyConfig(
+    taxonomy_fn = taxonomy_provider or default_taxonomy_provider
+    taxonomy = taxonomy_fn(
+        domain_objective,
+        TaxonomyConfig(
             max_depth=int(taxonomy_cfg.get("max_depth", 2)),
             branching_factor=int(taxonomy_cfg.get("branching_factor", 2)),
         ),
@@ -97,18 +108,17 @@ def run_pipeline(
     if pipeline_config is not None and not pipeline_config.get("local_diversification_enabled", True):
         local_options["per_node_instantiation_count"] = 1
 
-    local_diversification = build_local_diversification(
-        taxonomy=taxonomy,
-        options=local_options or None,
-    )
+    local_fn = local_diversification_provider or default_local_diversification_provider
+    local_diversification = local_fn(taxonomy, options=local_options or None)
     local_artifacts = store.persist_local_diversification(local_diversification)
 
     complex_cfg = dict(complexification_config or {})
     if pipeline_config is not None and not pipeline_config.get("complexification_enabled", True):
         complex_cfg["complexify_fraction"] = 0.0
 
-    complexification = apply_complexification(
-        samples=local_diversification["instantiations"],
+    complex_fn = complexification_provider or default_complexification_provider
+    complexification = complex_fn(
+        local_diversification["instantiations"],
         complexify_fraction=float(complex_cfg.get("complexify_fraction", 0.75)),
         semantic_overlap_threshold=float(complex_cfg.get("semantic_overlap_threshold", 0.55)),
         strategy=str(complex_cfg.get("strategy", "append_reasoning")),

--- a/src/simula_research/provider_protocols.py
+++ b/src/simula_research/provider_protocols.py
@@ -4,6 +4,10 @@ import hashlib
 from collections.abc import Mapping
 from typing import Any, Literal, Protocol
 
+from simula_research.complexification import apply_complexification
+from simula_research.local_diversification import build_local_diversification
+from simula_research.taxonomy import TaxonomyConfig, build_taxonomy
+
 CriticVerdict = Literal["accept", "reject"]
 
 
@@ -17,6 +21,58 @@ class CriticSampleEvaluatorFn(Protocol):
     """Provider-facing hook (Issue #22): full Stage-3 sample dict (lineage, flags, text) per critic."""
 
     def __call__(self, sample: dict[str, Any], critic_id: str) -> CriticVerdict: ...
+
+
+class TaxonomyProviderFn(Protocol):
+    """Stage 1 hook (Issue #60): taxonomy / global diversification."""
+
+    def __call__(self, domain_objective: str, config: TaxonomyConfig | None = None) -> dict[str, Any]: ...
+
+
+class LocalDiversificationProviderFn(Protocol):
+    """Stage 2 hook (Issue #60): local diversification from taxonomy handoff."""
+
+    def __call__(self, taxonomy: dict[str, Any], *, options: dict[str, Any] | None = None) -> dict[str, Any]: ...
+
+
+class ComplexificationProviderFn(Protocol):
+    """Stage 3 hook (Issue #60): complexification from local instantiations."""
+
+    def __call__(
+        self,
+        samples: list[dict[str, Any]],
+        *,
+        complexify_fraction: float = 0.75,
+        semantic_overlap_threshold: float = 0.55,
+        strategy: str = "append_reasoning",
+    ) -> dict[str, Any]: ...
+
+
+def default_taxonomy_provider(domain_objective: str, config: TaxonomyConfig | None = None) -> dict[str, Any]:
+    return build_taxonomy(domain_objective, config)
+
+
+def default_local_diversification_provider(
+    taxonomy: dict[str, Any],
+    *,
+    options: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return build_local_diversification(taxonomy=taxonomy, options=options)
+
+
+def default_complexification_provider(
+    samples: list[dict[str, Any]],
+    *,
+    complexify_fraction: float = 0.75,
+    semantic_overlap_threshold: float = 0.55,
+    strategy: str = "append_reasoning",
+) -> dict[str, Any]:
+    return apply_complexification(
+        samples=samples,
+        complexify_fraction=complexify_fraction,
+        semantic_overlap_threshold=semantic_overlap_threshold,
+        strategy=strategy,
+    )
 
 
 def sample_evaluator_from_text_fn(text_fn: CriticVerdictFn) -> CriticSampleEvaluatorFn:
@@ -47,3 +103,11 @@ def hash_based_critic_verdict(text: str, critic_id: str) -> CriticVerdict:
     _ = critic_id
     digest = hashlib.sha1(text.encode("utf-8")).hexdigest()
     return "accept" if int(digest[:2], 16) % 2 == 0 else "reject"
+
+
+def hash_based_critic_sample_evaluator(sample: dict[str, Any], critic_id: str) -> CriticVerdict:
+    """Offline default: lineage-keyed verdict with dual-critic parity (critic_id ignored)."""
+    _ = critic_id
+    lineage_key = f"{sample.get('taxonomy_node_id', '')}::{sample.get('instantiation_id', '')}"
+    digest = hashlib.sha1(lineage_key.encode("utf-8")).hexdigest()
+    return "accept" if int(digest[:2], 16) % 10 < 8 else "reject"

--- a/tests/fixtures/issue60/complexification_pilot_domain_depth2.json
+++ b/tests/fixtures/issue60/complexification_pilot_domain_depth2.json
@@ -1,0 +1,108 @@
+{
+  "complexification_policy": {
+    "complexify_fraction": 0.75,
+    "semantic_overlap_threshold": 0.55,
+    "strategy": "append_reasoning"
+  },
+  "samples": [
+    {
+      "complexity_source": "complexification_transform_v1",
+      "instantiation_id": "inst-ab14ade2f9e4",
+      "is_complexified": true,
+      "lineage": {
+        "instantiation_id": "inst-ab14ade2f9e4",
+        "meta_prompt_id": "mp-5e9181892c2b",
+        "taxonomy_node_id": "tax-9f7348228a8e"
+      },
+      "meta_prompt_id": "mp-5e9181892c2b",
+      "source_intent": "pilot-domain::pilot-domain root example 0. Reasoning path for pilot-domain root under tax-9f7348228a8e.",
+      "taxonomy_node_id": "tax-9f7348228a8e",
+      "text": "pilot-domain::pilot-domain root example 0. Reasoning path for pilot-domain root under tax-9f7348228a8e. Include a multi-step justification, evaluate one plausible distractor, and articulate why the final decision resolves ambiguity."
+    },
+    {
+      "complexity_source": "complexification_transform_v1",
+      "instantiation_id": "inst-927674b0d4b7",
+      "is_complexified": true,
+      "lineage": {
+        "instantiation_id": "inst-927674b0d4b7",
+        "meta_prompt_id": "mp-e19631a768fb",
+        "taxonomy_node_id": "tax-079d4f2d6823"
+      },
+      "meta_prompt_id": "mp-e19631a768fb",
+      "source_intent": "pilot-domain::pilot-domain root pilot fundamentals example 0. Reasoning path for pilot-domain root pilot fundamentals under tax-079d4f2d6823.",
+      "taxonomy_node_id": "tax-079d4f2d6823",
+      "text": "pilot-domain::pilot-domain root pilot fundamentals example 0. Reasoning path for pilot-domain root pilot fundamentals under tax-079d4f2d6823. Include a multi-step justification, evaluate one plausible distractor, and articulate why the final decision resolves ambiguity."
+    },
+    {
+      "complexity_source": "complexification_transform_v1",
+      "instantiation_id": "inst-1f4968f031a4",
+      "is_complexified": true,
+      "lineage": {
+        "instantiation_id": "inst-1f4968f031a4",
+        "meta_prompt_id": "mp-e7c54dcd56a0",
+        "taxonomy_node_id": "tax-1827300b6107"
+      },
+      "meta_prompt_id": "mp-e7c54dcd56a0",
+      "source_intent": "pilot-domain::pilot-domain root pilot advanced example 0. Reasoning path for pilot-domain root pilot advanced under tax-1827300b6107.",
+      "taxonomy_node_id": "tax-1827300b6107",
+      "text": "pilot-domain::pilot-domain root pilot advanced example 0. Reasoning path for pilot-domain root pilot advanced under tax-1827300b6107. Include a multi-step justification, evaluate one plausible distractor, and articulate why the final decision resolves ambiguity."
+    },
+    {
+      "complexity_source": "complexification_transform_v1",
+      "instantiation_id": "inst-443d84567e65",
+      "is_complexified": true,
+      "lineage": {
+        "instantiation_id": "inst-443d84567e65",
+        "meta_prompt_id": "mp-559a27c32dca",
+        "taxonomy_node_id": "tax-6ca519f1753d"
+      },
+      "meta_prompt_id": "mp-559a27c32dca",
+      "source_intent": "pilot-domain::pilot-domain root pilot fundamentals domain fundamentals example 0. Reasoning path for pilot-domain root pilot fundamentals domain fundamentals under tax-6ca519f1753d.",
+      "taxonomy_node_id": "tax-6ca519f1753d",
+      "text": "pilot-domain::pilot-domain root pilot fundamentals domain fundamentals example 0. Reasoning path for pilot-domain root pilot fundamentals domain fundamentals under tax-6ca519f1753d. Include a multi-step justification, evaluate one plausible distractor, and articulate why the final decision resolves ambiguity."
+    },
+    {
+      "complexity_source": "complexification_transform_v1",
+      "instantiation_id": "inst-b6350a55bb7a",
+      "is_complexified": true,
+      "lineage": {
+        "instantiation_id": "inst-b6350a55bb7a",
+        "meta_prompt_id": "mp-eac0f6036b1e",
+        "taxonomy_node_id": "tax-6123d0c8daae"
+      },
+      "meta_prompt_id": "mp-eac0f6036b1e",
+      "source_intent": "pilot-domain::pilot-domain root pilot fundamentals domain advanced example 0. Reasoning path for pilot-domain root pilot fundamentals domain advanced under tax-6123d0c8daae.",
+      "taxonomy_node_id": "tax-6123d0c8daae",
+      "text": "pilot-domain::pilot-domain root pilot fundamentals domain advanced example 0. Reasoning path for pilot-domain root pilot fundamentals domain advanced under tax-6123d0c8daae. Include a multi-step justification, evaluate one plausible distractor, and articulate why the final decision resolves ambiguity."
+    },
+    {
+      "complexity_source": "original",
+      "instantiation_id": "inst-f59075d1f03d",
+      "is_complexified": false,
+      "lineage": {
+        "instantiation_id": "inst-f59075d1f03d",
+        "meta_prompt_id": "mp-1ec2b48a7cfb",
+        "taxonomy_node_id": "tax-9d4dee183241"
+      },
+      "meta_prompt_id": "mp-1ec2b48a7cfb",
+      "source_intent": "pilot-domain::pilot-domain root pilot advanced domain fundamentals example 0. Reasoning path for pilot-domain root pilot advanced domain fundamentals under tax-9d4dee183241.",
+      "taxonomy_node_id": "tax-9d4dee183241",
+      "text": "pilot-domain::pilot-domain root pilot advanced domain fundamentals example 0. Reasoning path for pilot-domain root pilot advanced domain fundamentals under tax-9d4dee183241."
+    },
+    {
+      "complexity_source": "original",
+      "instantiation_id": "inst-b6092663b84f",
+      "is_complexified": false,
+      "lineage": {
+        "instantiation_id": "inst-b6092663b84f",
+        "meta_prompt_id": "mp-5b931f1097d0",
+        "taxonomy_node_id": "tax-959ac88dd20b"
+      },
+      "meta_prompt_id": "mp-5b931f1097d0",
+      "source_intent": "pilot-domain::pilot-domain root pilot advanced domain advanced example 0. Reasoning path for pilot-domain root pilot advanced domain advanced under tax-959ac88dd20b.",
+      "taxonomy_node_id": "tax-959ac88dd20b",
+      "text": "pilot-domain::pilot-domain root pilot advanced domain advanced example 0. Reasoning path for pilot-domain root pilot advanced domain advanced under tax-959ac88dd20b."
+    }
+  ],
+  "semantic_preservation_failures": []
+}

--- a/tests/fixtures/issue60/local_diversification_pilot_domain_depth2.json
+++ b/tests/fixtures/issue60/local_diversification_pilot_domain_depth2.json
@@ -1,0 +1,172 @@
+{
+  "anti_collapse_checks": {
+    "check_name": "token_overlap_rejection",
+    "executed": true,
+    "threshold": 0.8
+  },
+  "instantiations": [
+    {
+      "instantiation_id": "inst-ab14ade2f9e4",
+      "lineage": {
+        "instantiation_id": "inst-ab14ade2f9e4",
+        "meta_prompt_id": "mp-5e9181892c2b",
+        "taxonomy_node_id": "tax-9f7348228a8e"
+      },
+      "meta_prompt_id": "mp-5e9181892c2b",
+      "taxonomy_node_id": "tax-9f7348228a8e",
+      "text": "pilot-domain::pilot-domain root example 0. Reasoning path for pilot-domain root under tax-9f7348228a8e."
+    },
+    {
+      "instantiation_id": "inst-927674b0d4b7",
+      "lineage": {
+        "instantiation_id": "inst-927674b0d4b7",
+        "meta_prompt_id": "mp-e19631a768fb",
+        "taxonomy_node_id": "tax-079d4f2d6823"
+      },
+      "meta_prompt_id": "mp-e19631a768fb",
+      "taxonomy_node_id": "tax-079d4f2d6823",
+      "text": "pilot-domain::pilot-domain root pilot fundamentals example 0. Reasoning path for pilot-domain root pilot fundamentals under tax-079d4f2d6823."
+    },
+    {
+      "instantiation_id": "inst-1f4968f031a4",
+      "lineage": {
+        "instantiation_id": "inst-1f4968f031a4",
+        "meta_prompt_id": "mp-e7c54dcd56a0",
+        "taxonomy_node_id": "tax-1827300b6107"
+      },
+      "meta_prompt_id": "mp-e7c54dcd56a0",
+      "taxonomy_node_id": "tax-1827300b6107",
+      "text": "pilot-domain::pilot-domain root pilot advanced example 0. Reasoning path for pilot-domain root pilot advanced under tax-1827300b6107."
+    },
+    {
+      "instantiation_id": "inst-443d84567e65",
+      "lineage": {
+        "instantiation_id": "inst-443d84567e65",
+        "meta_prompt_id": "mp-559a27c32dca",
+        "taxonomy_node_id": "tax-6ca519f1753d"
+      },
+      "meta_prompt_id": "mp-559a27c32dca",
+      "taxonomy_node_id": "tax-6ca519f1753d",
+      "text": "pilot-domain::pilot-domain root pilot fundamentals domain fundamentals example 0. Reasoning path for pilot-domain root pilot fundamentals domain fundamentals under tax-6ca519f1753d."
+    },
+    {
+      "instantiation_id": "inst-b6350a55bb7a",
+      "lineage": {
+        "instantiation_id": "inst-b6350a55bb7a",
+        "meta_prompt_id": "mp-eac0f6036b1e",
+        "taxonomy_node_id": "tax-6123d0c8daae"
+      },
+      "meta_prompt_id": "mp-eac0f6036b1e",
+      "taxonomy_node_id": "tax-6123d0c8daae",
+      "text": "pilot-domain::pilot-domain root pilot fundamentals domain advanced example 0. Reasoning path for pilot-domain root pilot fundamentals domain advanced under tax-6123d0c8daae."
+    },
+    {
+      "instantiation_id": "inst-f59075d1f03d",
+      "lineage": {
+        "instantiation_id": "inst-f59075d1f03d",
+        "meta_prompt_id": "mp-1ec2b48a7cfb",
+        "taxonomy_node_id": "tax-9d4dee183241"
+      },
+      "meta_prompt_id": "mp-1ec2b48a7cfb",
+      "taxonomy_node_id": "tax-9d4dee183241",
+      "text": "pilot-domain::pilot-domain root pilot advanced domain fundamentals example 0. Reasoning path for pilot-domain root pilot advanced domain fundamentals under tax-9d4dee183241."
+    },
+    {
+      "instantiation_id": "inst-b6092663b84f",
+      "lineage": {
+        "instantiation_id": "inst-b6092663b84f",
+        "meta_prompt_id": "mp-5b931f1097d0",
+        "taxonomy_node_id": "tax-959ac88dd20b"
+      },
+      "meta_prompt_id": "mp-5b931f1097d0",
+      "taxonomy_node_id": "tax-959ac88dd20b",
+      "text": "pilot-domain::pilot-domain root pilot advanced domain advanced example 0. Reasoning path for pilot-domain root pilot advanced domain advanced under tax-959ac88dd20b."
+    }
+  ],
+  "rejections": [
+    {
+      "candidate_instantiation_id": "inst-8b9887e78a36",
+      "meta_prompt_id": "mp-5e9181892c2b",
+      "reason": "low_diversity",
+      "taxonomy_node_id": "tax-9f7348228a8e"
+    },
+    {
+      "candidate_instantiation_id": "inst-7b655f54cf65",
+      "meta_prompt_id": "mp-5e9181892c2b",
+      "reason": "low_diversity",
+      "taxonomy_node_id": "tax-9f7348228a8e"
+    },
+    {
+      "candidate_instantiation_id": "inst-a24821059e68",
+      "meta_prompt_id": "mp-e19631a768fb",
+      "reason": "low_diversity",
+      "taxonomy_node_id": "tax-079d4f2d6823"
+    },
+    {
+      "candidate_instantiation_id": "inst-7296f3f8d175",
+      "meta_prompt_id": "mp-e19631a768fb",
+      "reason": "low_diversity",
+      "taxonomy_node_id": "tax-079d4f2d6823"
+    },
+    {
+      "candidate_instantiation_id": "inst-3aa3fef96bd6",
+      "meta_prompt_id": "mp-e7c54dcd56a0",
+      "reason": "low_diversity",
+      "taxonomy_node_id": "tax-1827300b6107"
+    },
+    {
+      "candidate_instantiation_id": "inst-66116709b5b0",
+      "meta_prompt_id": "mp-e7c54dcd56a0",
+      "reason": "low_diversity",
+      "taxonomy_node_id": "tax-1827300b6107"
+    },
+    {
+      "candidate_instantiation_id": "inst-c29bcf233a5e",
+      "meta_prompt_id": "mp-559a27c32dca",
+      "reason": "low_diversity",
+      "taxonomy_node_id": "tax-6ca519f1753d"
+    },
+    {
+      "candidate_instantiation_id": "inst-3354ac67dcec",
+      "meta_prompt_id": "mp-559a27c32dca",
+      "reason": "low_diversity",
+      "taxonomy_node_id": "tax-6ca519f1753d"
+    },
+    {
+      "candidate_instantiation_id": "inst-19f2d9687bad",
+      "meta_prompt_id": "mp-eac0f6036b1e",
+      "reason": "low_diversity",
+      "taxonomy_node_id": "tax-6123d0c8daae"
+    },
+    {
+      "candidate_instantiation_id": "inst-a2ad7e9717b6",
+      "meta_prompt_id": "mp-eac0f6036b1e",
+      "reason": "low_diversity",
+      "taxonomy_node_id": "tax-6123d0c8daae"
+    },
+    {
+      "candidate_instantiation_id": "inst-14b124382d3f",
+      "meta_prompt_id": "mp-1ec2b48a7cfb",
+      "reason": "low_diversity",
+      "taxonomy_node_id": "tax-9d4dee183241"
+    },
+    {
+      "candidate_instantiation_id": "inst-33f794de374d",
+      "meta_prompt_id": "mp-1ec2b48a7cfb",
+      "reason": "low_diversity",
+      "taxonomy_node_id": "tax-9d4dee183241"
+    },
+    {
+      "candidate_instantiation_id": "inst-b2c8326c3ddf",
+      "meta_prompt_id": "mp-5b931f1097d0",
+      "reason": "low_diversity",
+      "taxonomy_node_id": "tax-959ac88dd20b"
+    },
+    {
+      "candidate_instantiation_id": "inst-6158ea2ef878",
+      "meta_prompt_id": "mp-5b931f1097d0",
+      "reason": "low_diversity",
+      "taxonomy_node_id": "tax-959ac88dd20b"
+    }
+  ]
+}

--- a/tests/fixtures/issue60/taxonomy_pilot_domain_depth2.json
+++ b/tests/fixtures/issue60/taxonomy_pilot_domain_depth2.json
@@ -1,0 +1,100 @@
+{
+  "domain_namespace": "pilot-domain",
+  "edges": [
+    {
+      "parent_taxonomy_node_id": "tax-9f7348228a8e",
+      "taxonomy_node_id": "tax-079d4f2d6823"
+    },
+    {
+      "parent_taxonomy_node_id": "tax-9f7348228a8e",
+      "taxonomy_node_id": "tax-1827300b6107"
+    },
+    {
+      "parent_taxonomy_node_id": "tax-079d4f2d6823",
+      "taxonomy_node_id": "tax-6ca519f1753d"
+    },
+    {
+      "parent_taxonomy_node_id": "tax-079d4f2d6823",
+      "taxonomy_node_id": "tax-6123d0c8daae"
+    },
+    {
+      "parent_taxonomy_node_id": "tax-1827300b6107",
+      "taxonomy_node_id": "tax-9d4dee183241"
+    },
+    {
+      "parent_taxonomy_node_id": "tax-1827300b6107",
+      "taxonomy_node_id": "tax-959ac88dd20b"
+    }
+  ],
+  "generation_policy": {
+    "branching_factor": 2,
+    "max_depth": 2,
+    "merge_filter_strategy": "normalize+deduplicate+parent-filter"
+  },
+  "nodes": [
+    {
+      "branch_source": "seed",
+      "confidence": 1.0,
+      "depth": 0,
+      "label": "pilot-domain root",
+      "notes": "root taxonomy node",
+      "parent_taxonomy_node_id": null,
+      "taxonomy_node_id": "tax-9f7348228a8e"
+    },
+    {
+      "branch_source": "recursive-expansion",
+      "confidence": 0.8,
+      "depth": 1,
+      "label": "pilot-domain root pilot fundamentals",
+      "notes": "generated from parent tax-9f7348228a8e",
+      "parent_taxonomy_node_id": "tax-9f7348228a8e",
+      "taxonomy_node_id": "tax-079d4f2d6823"
+    },
+    {
+      "branch_source": "recursive-expansion",
+      "confidence": 0.8,
+      "depth": 1,
+      "label": "pilot-domain root pilot advanced",
+      "notes": "generated from parent tax-9f7348228a8e",
+      "parent_taxonomy_node_id": "tax-9f7348228a8e",
+      "taxonomy_node_id": "tax-1827300b6107"
+    },
+    {
+      "branch_source": "recursive-expansion",
+      "confidence": 0.8,
+      "depth": 2,
+      "label": "pilot-domain root pilot fundamentals domain fundamentals",
+      "notes": "generated from parent tax-079d4f2d6823",
+      "parent_taxonomy_node_id": "tax-079d4f2d6823",
+      "taxonomy_node_id": "tax-6ca519f1753d"
+    },
+    {
+      "branch_source": "recursive-expansion",
+      "confidence": 0.8,
+      "depth": 2,
+      "label": "pilot-domain root pilot fundamentals domain advanced",
+      "notes": "generated from parent tax-079d4f2d6823",
+      "parent_taxonomy_node_id": "tax-079d4f2d6823",
+      "taxonomy_node_id": "tax-6123d0c8daae"
+    },
+    {
+      "branch_source": "recursive-expansion",
+      "confidence": 0.8,
+      "depth": 2,
+      "label": "pilot-domain root pilot advanced domain fundamentals",
+      "notes": "generated from parent tax-1827300b6107",
+      "parent_taxonomy_node_id": "tax-1827300b6107",
+      "taxonomy_node_id": "tax-9d4dee183241"
+    },
+    {
+      "branch_source": "recursive-expansion",
+      "confidence": 0.8,
+      "depth": 2,
+      "label": "pilot-domain root pilot advanced domain advanced",
+      "notes": "generated from parent tax-1827300b6107",
+      "parent_taxonomy_node_id": "tax-1827300b6107",
+      "taxonomy_node_id": "tax-959ac88dd20b"
+    }
+  ],
+  "root_taxonomy_node_id": "tax-9f7348228a8e"
+}

--- a/tests/test_issue60_stage_provider_protocols.py
+++ b/tests/test_issue60_stage_provider_protocols.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+from simula_research.complexification import apply_complexification
+from simula_research.local_diversification import build_local_diversification
+from simula_research.pipeline import run_pipeline
+from simula_research.provider_protocols import (
+    default_complexification_provider,
+    default_local_diversification_provider,
+    default_taxonomy_provider,
+)
+from simula_research.stage_contracts import validate_stage_handoffs
+from simula_research.taxonomy import TaxonomyConfig, build_taxonomy
+
+FIXTURES = Path(__file__).parent / "fixtures" / "issue60"
+GOLDEN_DOMAIN = "pilot-domain"
+GOLDEN_TAXONOMY_CONFIG = TaxonomyConfig(max_depth=2, branching_factor=2)
+GOLDEN_LOCAL_OPTIONS: dict[str, Any] = {"per_node_instantiation_count": 3}
+GOLDEN_COMPLEX_KWARGS: dict[str, Any] = {
+    "complexify_fraction": 0.75,
+    "semantic_overlap_threshold": 0.55,
+    "strategy": "append_reasoning",
+}
+
+
+def _load_fixture(name: str) -> Any:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+class Issue60StageProviderProtocolsTests(unittest.TestCase):
+    def test_default_taxonomy_provider_matches_build_taxonomy(self) -> None:
+        direct = build_taxonomy(GOLDEN_DOMAIN, GOLDEN_TAXONOMY_CONFIG)
+        via_provider = default_taxonomy_provider(GOLDEN_DOMAIN, GOLDEN_TAXONOMY_CONFIG)
+        self.assertEqual(_canonical_json(direct), _canonical_json(via_provider))
+
+    def test_default_local_diversification_provider_matches_build(self) -> None:
+        taxonomy = build_taxonomy(GOLDEN_DOMAIN, GOLDEN_TAXONOMY_CONFIG)
+        direct = build_local_diversification(taxonomy=taxonomy, options=GOLDEN_LOCAL_OPTIONS)
+        via_provider = default_local_diversification_provider(taxonomy=taxonomy, options=GOLDEN_LOCAL_OPTIONS)
+        self.assertEqual(_canonical_json(direct), _canonical_json(via_provider))
+
+    def test_default_complexification_provider_matches_apply(self) -> None:
+        taxonomy = build_taxonomy(GOLDEN_DOMAIN, GOLDEN_TAXONOMY_CONFIG)
+        local = build_local_diversification(taxonomy=taxonomy, options=GOLDEN_LOCAL_OPTIONS)
+        direct = apply_complexification(samples=local["instantiations"], **GOLDEN_COMPLEX_KWARGS)
+        via_provider = default_complexification_provider(
+            samples=local["instantiations"], **GOLDEN_COMPLEX_KWARGS
+        )
+        self.assertEqual(_canonical_json(direct), _canonical_json(via_provider))
+
+    def test_golden_fixtures_match_default_providers(self) -> None:
+        taxonomy = default_taxonomy_provider(GOLDEN_DOMAIN, GOLDEN_TAXONOMY_CONFIG)
+        local = default_local_diversification_provider(taxonomy=taxonomy, options=GOLDEN_LOCAL_OPTIONS)
+        comp = default_complexification_provider(samples=local["instantiations"], **GOLDEN_COMPLEX_KWARGS)
+        self.assertEqual(_canonical_json(taxonomy), _canonical_json(_load_fixture("taxonomy_pilot_domain_depth2.json")))
+        self.assertEqual(
+            _canonical_json(local),
+            _canonical_json(_load_fixture("local_diversification_pilot_domain_depth2.json")),
+        )
+        self.assertEqual(
+            _canonical_json(comp),
+            _canonical_json(_load_fixture("complexification_pilot_domain_depth2.json")),
+        )
+
+    def test_run_pipeline_implicit_defaults_match_golden_chain(self) -> None:
+        captured: dict[str, Any] = {}
+
+        class CapturingStore:
+            def __init__(self, run_root: Path) -> None:
+                self.run_root = run_root
+
+            def persist_taxonomy(self, taxonomy: dict[str, Any]) -> dict[str, str]:
+                captured["taxonomy"] = taxonomy
+                return {"taxonomy_graph": str(self.run_root / "g.json"), "taxonomy_nodes": str(self.run_root / "n.json")}
+
+            def persist_local_diversification(self, local_diversification: dict[str, Any]) -> dict[str, str]:
+                captured["local_diversification"] = local_diversification
+                return {"instantiations": str(self.run_root / "i.json"), "rejections": str(self.run_root / "r.json")}
+
+            def persist_complexification(self, complexification: dict[str, Any]) -> dict[str, str]:
+                captured["complexification"] = complexification
+                return {"samples": str(self.run_root / "s.json"), "semantic_preservation_failures": str(self.run_root / "f.json")}
+
+            def persist_dual_critic(self, adjudication: dict[str, Any]) -> dict[str, str]:
+                captured["adjudication"] = adjudication
+                return {
+                    "critic_decisions": str(self.run_root / "d.json"),
+                    "rejections": str(self.run_root / "rj.json"),
+                    "regenerations": str(self.run_root / "rg.json"),
+                }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_pipeline(
+                seed=60,
+                model_ids={"generator": "g", "critic_a": "a", "critic_b": "b"},
+                domain_objective=GOLDEN_DOMAIN,
+                artifact_root=tmp,
+                taxonomy_config={"max_depth": 2, "branching_factor": 2},
+                artifact_store_factory=lambda root: CapturingStore(root),
+            )
+
+        self.assertEqual(
+            _canonical_json(captured["taxonomy"]),
+            _canonical_json(_load_fixture("taxonomy_pilot_domain_depth2.json")),
+        )
+        self.assertEqual(
+            _canonical_json(captured["local_diversification"]),
+            _canonical_json(_load_fixture("local_diversification_pilot_domain_depth2.json")),
+        )
+        self.assertEqual(
+            _canonical_json(captured["complexification"]),
+            _canonical_json(_load_fixture("complexification_pilot_domain_depth2.json")),
+        )
+        validate_stage_handoffs(
+            taxonomy=captured["taxonomy"],
+            local_diversification=captured["local_diversification"],
+            complexification=captured["complexification"],
+            adjudication=captured["adjudication"],
+        )
+        self.assertEqual(
+            result["taxonomy"]["root_taxonomy_node_id"],
+            captured["taxonomy"]["root_taxonomy_node_id"],
+        )
+
+    def test_run_pipeline_explicit_default_providers_match_implicit(self) -> None:
+        implicit: dict[str, Any] = {}
+        explicit: dict[str, Any] = {}
+
+        def _capturing(target: dict[str, Any]):
+            class CapturingStore:
+                def __init__(self, run_root: Path) -> None:
+                    self.run_root = run_root
+
+                def persist_taxonomy(self, taxonomy: dict[str, Any]) -> dict[str, str]:
+                    target["taxonomy"] = taxonomy
+                    return {"taxonomy_graph": "g", "taxonomy_nodes": "n"}
+
+                def persist_local_diversification(self, local_diversification: dict[str, Any]) -> dict[str, str]:
+                    target["local_diversification"] = local_diversification
+                    return {"instantiations": "i", "rejections": "r"}
+
+                def persist_complexification(self, complexification: dict[str, Any]) -> dict[str, str]:
+                    target["complexification"] = complexification
+                    return {"samples": "s", "semantic_preservation_failures": "f"}
+
+                def persist_dual_critic(self, adjudication: dict[str, Any]) -> dict[str, str]:
+                    target["adjudication"] = adjudication
+                    return {"critic_decisions": "d", "rejections": "rj", "regenerations": "rg"}
+
+            return CapturingStore
+
+        common = dict(
+            seed=60,
+            model_ids={"generator": "g", "critic_a": "a", "critic_b": "b"},
+            domain_objective=GOLDEN_DOMAIN,
+            taxonomy_config={"max_depth": 2, "branching_factor": 2},
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            run_pipeline(**common, artifact_root=tmp, artifact_store_factory=lambda root: _capturing(implicit)(root))
+            run_pipeline(
+                **common,
+                artifact_root=tmp,
+                artifact_store_factory=lambda root: _capturing(explicit)(root),
+                taxonomy_provider=default_taxonomy_provider,
+                local_diversification_provider=default_local_diversification_provider,
+                complexification_provider=default_complexification_provider,
+            )
+
+        for key in ("taxonomy", "local_diversification", "complexification"):
+            self.assertEqual(
+                _canonical_json(implicit[key]),
+                _canonical_json(explicit[key]),
+                msg=f"{key} differs between implicit and explicit default providers",
+            )
+
+    def test_custom_taxonomy_provider_is_invoked(self) -> None:
+        seen: list[str] = []
+
+        def stub_taxonomy(domain_objective: str, config: TaxonomyConfig | None = None) -> dict[str, Any]:
+            seen.append(domain_objective)
+            return build_taxonomy(domain_objective, TaxonomyConfig(max_depth=0, branching_factor=1))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_pipeline(
+                seed=1,
+                model_ids={"generator": "g", "critic_a": "a", "critic_b": "b"},
+                domain_objective="custom-domain",
+                artifact_root=tmp,
+                taxonomy_provider=stub_taxonomy,
+            )
+
+        self.assertEqual(seen, ["custom-domain"])
+        self.assertEqual(result["stage_outputs"]["stage_1_global_diversification"]["taxonomy_node_count"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `TaxonomyProviderFn`, `LocalDiversificationProviderFn`, and `ComplexificationProviderFn` protocols plus default provider callables in `provider_protocols.py`, mirroring the existing critic/artifact-store seam pattern (ADR 0004 / Issue #60).
- Wires optional `taxonomy_provider`, `local_diversification_provider`, and `complexification_provider` parameters on `run_pipeline`; omitted hooks delegate to `default_*` implementations with no behavior change.
- Adds golden JSON fixtures and `tests/test_issue60_stage_provider_protocols.py` proving bit-identical Stage 1–3 outputs and stage handoff validation on the default path.

## Test plan

- [x] `PYTHONPATH=src python3 -m unittest discover -s tests -p "test_*.py"` (83 tests, all green)
- [x] Golden fixtures match default providers for `pilot-domain` / depth 2 / default complexification kwargs
- [x] Implicit vs explicit default providers produce identical captured stage payloads
- [x] No ADR 0003 threshold/metric/gate changes

Closes #60


Made with [Cursor](https://cursor.com)